### PR TITLE
Token blacklisting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,4 +44,4 @@ run-coordinator:
 	aws s3 rm s3://${AWS_S3_BUCKET} --recursive
 	RUST_LOG=debug $(CARGO) run --features=parallel --bin phase1-coordinator
 
-.PHONY : build check clean clippy clippy-fix close-ceremony fmt get-contributions run-coordinator test-coordinator test-e2e update verify
+.PHONY : build check clean clippy clippy-fix close-ceremony fmt get-contributions run-coordinator update verify

--- a/phase1-cli/src/bin/namada-ts.rs
+++ b/phase1-cli/src/bin/namada-ts.rs
@@ -430,7 +430,10 @@ async fn contribution_loop(
     mut contrib_info: ContributionInfo,
 ) {
     println!("{} Joining queue", "[3/11]".bold().dimmed());
-    println!("{}","You can only join the ceremony with the unique token you received by email for your cohort.".bright_cyan());
+    println!(
+        "{}",
+        "You can only join the ceremony with the unique token you received by email for your cohort.".bright_cyan()
+    );
     let token = io::get_user_input(
         "Enter your token:".bright_yellow(),
         Some(&Regex::new(TOKEN_REGEX).unwrap()),

--- a/phase1-cli/tests/e2e.rs
+++ b/phase1-cli/tests/e2e.rs
@@ -57,6 +57,8 @@ struct TestCtx {
     unknown_participant: TestParticipant,
     coordinator: TestParticipant,
     coordinator_url: String,
+    // Keep TempDir in scope for some tests
+    _tokens_tmp_dir: tempfile::TempDir
 }
 
 /// Launch the rocket server for testing with the proper configuration as a separate async Task.
@@ -192,6 +194,7 @@ async fn test_prelude() -> (TestCtx, JoinHandle<Result<Rocket<Ignite>, Error>>) 
         unknown_participant,
         coordinator: coord_verifier,
         coordinator_url,
+        _tokens_tmp_dir: tmp_dir
     };
 
     (ctx, handle)

--- a/phase1-cli/tests/e2e.rs
+++ b/phase1-cli/tests/e2e.rs
@@ -264,7 +264,9 @@ async fn test_update_cohorts() {
     std::fs::remove_file(TOKENS_ZIP_FILE).ok();
 
     // Create new tokens zip file
-    let new_invalid_tokens = get_serialized_tokens_zip(vec!["[\"9nFeNpukSn1eVwNc2vkfP7rdLh2njm5ewmCGxSLTW3GYmKP51fKjbRUvHDmntjEaQiq7iFux9tumgWEWVHwHQCs31oitpqBpMWpMydo1DnuFyLpsD6C\", \"9nFeNpukSn1eVwNc2vkfP7sQsLG3oS7623phb2Zzc23GAdXjuby4XAbwbWbx1uNaYrZorVLio4ZSt3u95sgi4fsS8hiZ3XkEttBF6q4461dGpoWv7ek\"]"]);
+    let new_invalid_tokens = get_serialized_tokens_zip(vec![
+        "[\"9nFeNpukSn1eVwNc2vkfP7rdLh2njm5ewmCGxSLTW3GYmKP51fKjbRUvHDmntjEaQiq7iFux9tumgWEWVHwHQCs31oitpqBpMWpMydo1DnuFyLpsD6C\", \"9nFeNpukSn1eVwNc2vkfP7sQsLG3oS7623phb2Zzc23GAdXjuby4XAbwbWbx1uNaYrZorVLio4ZSt3u95sgi4fsS8hiZ3XkEttBF6q4461dGpoWv7ek\"]",
+    ]);
 
     // Wrong, request from non-coordinator participant
     let url = Url::parse(&ctx.coordinator_url).unwrap();

--- a/phase1-cli/tests/e2e.rs
+++ b/phase1-cli/tests/e2e.rs
@@ -83,7 +83,7 @@ async fn test_prelude() -> (TestCtx, JoinHandle<Result<Rocket<Ignite>, Error>>) 
     let file_path = tmp_dir.path().join("namada_tokens_cohort_1.json");
     let mut token_file = std::fs::File::create(file_path).unwrap();
     token_file
-        .write_all("[\"7fe7c70eda056784fcf4\", \"4eb8d831fdd098390683\", \"4935c7fbd09e4f925f75\"]".as_bytes())
+        .write_all("[\"9nFeNpukSn1eVwNc2vkfP7rdLh2njm5ewmCGxSLTW3GYmKP51fKjbRUvHDmntjEaQiq7iFux9tumgWEWVHwHQCs31oitpqBpMWpMydo1DnuFyLpsD6C\", \"9nFeNpukSn1eVwNc2vkfP7sQsLG3oS7623phb2Zzc23GAdXjuby4XAbwbWbx1uNaYrZorVLio4ZSt3u95sgi4fsS8hiZ3XkEttBF6q4461dGpoWv7ek\", \"9nFeNpukSn1eVwNc2vkfP8SP4HrxTh9F86CY5pNWw8RF3jZa91q2i3yvE7ugpn9w2RzoZBZrdskgckmvJuVKq6ZWxfV8TepZYFd9SeARGHexi7tGGV2\"]".as_bytes())
         .unwrap();
     std::env::set_var("NAMADA_TOKENS_PATH", tmp_dir.path());
     std::env::set_var("TOKENS_FILE_PREFIX", "namada_tokens_cohort");
@@ -130,7 +130,7 @@ async fn test_prelude() -> (TestCtx, JoinHandle<Result<Rocket<Ignite>, Error>>) 
         .add_to_queue(
             contributor1.clone(),
             Some(contributor1_ip),
-            String::from("7fe7c70eda056784fcf4"),
+            String::from("9nFeNpukSn1eVwNc2vkfP7rdLh2njm5ewmCGxSLTW3GYmKP51fKjbRUvHDmntjEaQiq7iFux9tumgWEWVHwHQCs31oitpqBpMWpMydo1DnuFyLpsD6C"),
             10,
         )
         .unwrap();
@@ -264,7 +264,7 @@ async fn test_update_cohorts() {
     std::fs::remove_file(TOKENS_ZIP_FILE).ok();
 
     // Create new tokens zip file
-    let new_invalid_tokens = get_serialized_tokens_zip(vec!["[\"7fe7c70eda056784fcf4\", \"4eb8d831fdd098390683\"]"]);
+    let new_invalid_tokens = get_serialized_tokens_zip(vec!["[\"9nFeNpukSn1eVwNc2vkfP7rdLh2njm5ewmCGxSLTW3GYmKP51fKjbRUvHDmntjEaQiq7iFux9tumgWEWVHwHQCs31oitpqBpMWpMydo1DnuFyLpsD6C\", \"9nFeNpukSn1eVwNc2vkfP7sQsLG3oS7623phb2Zzc23GAdXjuby4XAbwbWbx1uNaYrZorVLio4ZSt3u95sgi4fsS8hiZ3XkEttBF6q4461dGpoWv7ek\"]"]);
 
     // Wrong, request from non-coordinator participant
     let url = Url::parse(&ctx.coordinator_url).unwrap();
@@ -280,8 +280,8 @@ async fn test_update_cohorts() {
 
     // Valid new tokens
     let new_valid_tokens = get_serialized_tokens_zip(vec![
-        "[\"7fe7c70eda056784fcf4\", \"4eb8d831fdd098390683\", \"4935c7fbd09e4f925f75\"]",
-        "[\"4935c7fbd09e4f925f11\"]",
+        "[\"9nFeNpukSn1eVwNc2vkfP7rdLh2njm5ewmCGxSLTW3GYmKP51fKjbRUvHDmntjEaQiq7iFux9tumgWEWVHwHQCs31oitpqBpMWpMydo1DnuFyLpsD6C\", \"9nFeNpukSn1eVwNc2vkfP7sQsLG3oS7623phb2Zzc23GAdXjuby4XAbwbWbx1uNaYrZorVLio4ZSt3u95sgi4fsS8hiZ3XkEttBF6q4461dGpoWv7ek\", \"9nFeNpukSn1eVwNc2vkfP8SP4HrxTh9F86CY5pNWw8RF3jZa91q2i3yvE7ugpn9w2RzoZBZrdskgckmvJuVKq6ZWxfV8TepZYFd9SeARGHexi7tGGV2\"]",
+        "[\"9nFeNpukSn1eVwNc2vkfP8TAaw6DXNAgCNpxiQc437BxT3iF2xUMdo6wYQjqwxHwAZjVhQzdH3QMpJSbXvaDcnkVu6Ktt22AfYDypK2h72vuQK9fGNp\"]",
     ]);
 
     let response = requests::post_update_cohorts(&client, &url, &ctx.coordinator.keypair, &new_valid_tokens).await;
@@ -311,9 +311,9 @@ async fn test_get_status() {
 
     // Check Json deserialization of CoordinatorState (RuntimeState must be empty)
     assert_eq!(status.get_tokens()[0].len(), 3);
-    assert!(status.get_tokens()[0].contains("7fe7c70eda056784fcf4"));
-    assert!(status.get_tokens()[0].contains("4eb8d831fdd098390683"));
-    assert!(status.get_tokens()[0].contains("4935c7fbd09e4f925f75"));
+    assert!(status.get_tokens()[0].contains("9nFeNpukSn1eVwNc2vkfP7rdLh2njm5ewmCGxSLTW3GYmKP51fKjbRUvHDmntjEaQiq7iFux9tumgWEWVHwHQCs31oitpqBpMWpMydo1DnuFyLpsD6C"));
+    assert!(status.get_tokens()[0].contains("9nFeNpukSn1eVwNc2vkfP7sQsLG3oS7623phb2Zzc23GAdXjuby4XAbwbWbx1uNaYrZorVLio4ZSt3u95sgi4fsS8hiZ3XkEttBF6q4461dGpoWv7ek"));
+    assert!(status.get_tokens()[0].contains("9nFeNpukSn1eVwNc2vkfP8SP4HrxTh9F86CY5pNWw8RF3jZa91q2i3yvE7ugpn9w2RzoZBZrdskgckmvJuVKq6ZWxfV8TepZYFd9SeARGHexi7tGGV2"));
     assert!(status.get_current_ips().is_empty());
     assert!(status.get_current_tokens().is_empty());
 
@@ -413,7 +413,7 @@ async fn test_join_queue() {
         &client,
         &url,
         &ctx.unknown_participant.keypair,
-        &String::from("7fe7c70eda056784fcf5"),
+        &String::from("9nFeNpukSn1eVwNc2vkfP7sQsLG3oS7623phb2Zzc23GAdXjuby4XAbwbWbx1uNaYrZorVLio4ZSt3u95sgi4fsS8hiZ3XkEttBF6q4461dGpoWv7er"),
     )
     .await;
     assert!(response.is_err());
@@ -427,7 +427,7 @@ async fn test_join_queue() {
         &client,
         &url,
         &ctx.unknown_participant.keypair,
-        &String::from("4eb8d831fdd098390683"),
+        &String::from("9nFeNpukSn1eVwNc2vkfP7sQsLG3oS7623phb2Zzc23GAdXjuby4XAbwbWbx1uNaYrZorVLio4ZSt3u95sgi4fsS8hiZ3XkEttBF6q4461dGpoWv7ek"),
     )
     .await
     .unwrap();
@@ -437,7 +437,7 @@ async fn test_join_queue() {
         &client,
         &url,
         &ctx.contributors[1].keypair,
-        &String::from("4eb8d831fdd098390683"),
+        &String::from("9nFeNpukSn1eVwNc2vkfP7sQsLG3oS7623phb2Zzc23GAdXjuby4XAbwbWbx1uNaYrZorVLio4ZSt3u95sgi4fsS8hiZ3XkEttBF6q4461dGpoWv7ek"),
     )
     .await;
     assert!(response.is_err());
@@ -447,7 +447,7 @@ async fn test_join_queue() {
         &client,
         &url,
         &ctx.unknown_participant.keypair,
-        &String::from("4935c7fbd09e4f925f75"),
+        &String::from("9nFeNpukSn1eVwNc2vkfP8SP4HrxTh9F86CY5pNWw8RF3jZa91q2i3yvE7ugpn9w2RzoZBZrdskgckmvJuVKq6ZWxfV8TepZYFd9SeARGHexi7tGGV2"),
     )
     .await;
     assert!(response.is_err());
@@ -677,8 +677,8 @@ async fn test_contribution() {
     // Update cohorts
     assert!(std::fs::metadata(TOKENS_ZIP_FILE).is_err());
     let new_valid_tokens = get_serialized_tokens_zip(vec![
-        "[\"7fe7c70eda056784fcf4\", \"4eb8d831fdd098390683\", \"4935c7fbd09e4f925f75\"]",
-        "[\"4935c7fbd09e4f925f11\"]",
+        "[\"9nFeNpukSn1eVwNc2vkfP7rdLh2njm5ewmCGxSLTW3GYmKP51fKjbRUvHDmntjEaQiq7iFux9tumgWEWVHwHQCs31oitpqBpMWpMydo1DnuFyLpsD6C\", \"9nFeNpukSn1eVwNc2vkfP7sQsLG3oS7623phb2Zzc23GAdXjuby4XAbwbWbx1uNaYrZorVLio4ZSt3u95sgi4fsS8hiZ3XkEttBF6q4461dGpoWv7ek\", \"9nFeNpukSn1eVwNc2vkfP8SP4HrxTh9F86CY5pNWw8RF3jZa91q2i3yvE7ugpn9w2RzoZBZrdskgckmvJuVKq6ZWxfV8TepZYFd9SeARGHexi7tGGV2\"]",
+        "[\"9nFeNpukSn1eVwNc2vkfP8TAaw6DXNAgCNpxiQc437BxT3iF2xUMdo6wYQjqwxHwAZjVhQzdH3QMpJSbXvaDcnkVu6Ktt22AfYDypK2h72vuQK9fGNp\"]",
     ]);
     let response = requests::post_update_cohorts(&client, &url, &ctx.coordinator.keypair, &new_valid_tokens).await;
     assert!(response.is_ok());
@@ -689,7 +689,7 @@ async fn test_contribution() {
         &client,
         &url,
         &ctx.unknown_participant.keypair,
-        &String::from("7fe7c70eda056784fcf4"),
+        &String::from("9nFeNpukSn1eVwNc2vkfP7rdLh2njm5ewmCGxSLTW3GYmKP51fKjbRUvHDmntjEaQiq7iFux9tumgWEWVHwHQCs31oitpqBpMWpMydo1DnuFyLpsD6C"),
     )
     .await;
     assert!(response.is_err());
@@ -702,7 +702,7 @@ async fn test_contribution() {
         &client,
         &url,
         &ctx.contributors[1].keypair,
-        &String::from("7fe7c70eda056784fcf4"),
+        &String::from("9nFeNpukSn1eVwNc2vkfP7rdLh2njm5ewmCGxSLTW3GYmKP51fKjbRUvHDmntjEaQiq7iFux9tumgWEWVHwHQCs31oitpqBpMWpMydo1DnuFyLpsD6C"),
     )
     .await;
     assert!(response.is_err());
@@ -712,7 +712,7 @@ async fn test_contribution() {
         &client,
         &url,
         &ctx.unknown_participant.keypair,
-        &String::from("4935c7fbd09e4f925f11"),
+        &String::from("9nFeNpukSn1eVwNc2vkfP8TAaw6DXNAgCNpxiQc437BxT3iF2xUMdo6wYQjqwxHwAZjVhQzdH3QMpJSbXvaDcnkVu6Ktt22AfYDypK2h72vuQK9fGNp"),
     )
     .await
     .unwrap();

--- a/phase1-cli/tests/e2e.rs
+++ b/phase1-cli/tests/e2e.rs
@@ -98,6 +98,9 @@ async fn test_prelude() -> (TestCtx, JoinHandle<Result<Rocket<Ignite>, Error>>) 
     let contributor2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let unknown_contributor_ip = IpAddr::V4("0.0.0.3".parse().unwrap());
 
+    let token = String::from("test-token");
+    let token2 = String::from("test-token-2");
+
     coordinator.initialize().unwrap();
     let coordinator_keypair = KeyPair::custom_new(
         coordinator.environment().default_verifier_signing_key(),
@@ -122,10 +125,10 @@ async fn test_prelude() -> (TestCtx, JoinHandle<Result<Rocket<Ignite>, Error>>) 
     };
 
     coordinator
-        .add_to_queue(contributor1.clone(), Some(contributor1_ip), 10)
+        .add_to_queue(contributor1.clone(), Some(contributor1_ip), token, 10)
         .unwrap();
     coordinator
-        .add_to_queue(contributor2.clone(), Some(contributor2_ip), 9)
+        .add_to_queue(contributor2.clone(), Some(contributor2_ip), token2, 9)
         .unwrap();
     coordinator.update().unwrap();
 

--- a/phase1-coordinator/src/coordinator.rs
+++ b/phase1-coordinator/src/coordinator.rs
@@ -648,8 +648,13 @@ impl Coordinator {
         reliability_score: u8,
     ) -> Result<(), CoordinatorError> {
         // Attempt to add the participant to the next round.
-        self.state
-            .add_to_queue(participant, participant_ip, token, reliability_score, self.time.as_ref())?;
+        self.state.add_to_queue(
+            participant,
+            participant_ip,
+            token,
+            reliability_score,
+            self.time.as_ref(),
+        )?;
 
         // Save the coordinator state in storage.
         self.save_state()?;

--- a/phase1-coordinator/src/coordinator.rs
+++ b/phase1-coordinator/src/coordinator.rs
@@ -12,6 +12,7 @@ use crate::{
         ParticipantInfo,
         ResetCurrentRoundStorageAction,
         RoundMetrics,
+        TokenState,
     },
     environment::{Deployment, Environment},
     objects::{
@@ -584,7 +585,7 @@ impl Coordinator {
     ///
     /// Updates the set of tokens for the ceremony
     ///
-    pub fn update_tokens(&mut self, tokens: Vec<HashSet<String>>) {
+    pub fn update_tokens(&mut self, tokens: Vec<HashMap<String, (Participant, TokenState)>>) {
         self.state.update_tokens(tokens)
     }
 

--- a/phase1-coordinator/src/coordinator.rs
+++ b/phase1-coordinator/src/coordinator.rs
@@ -386,7 +386,7 @@ impl Coordinator {
         // Load an instance of storage.
         let storage = environment.storage()?;
         // Load an instance of coordinator self.
-        let state = match storage.get(&Locator::CoordinatorState)? { //FIXME: how does it handle tmp_state which is not in the file, should recreate it with Default
+        let state = match storage.get(&Locator::CoordinatorState)? {
             Object::CoordinatorState(state) => state,
             _ => return Err(CoordinatorError::StorageFailed),
         };

--- a/phase1-coordinator/src/coordinator.rs
+++ b/phase1-coordinator/src/coordinator.rs
@@ -2853,7 +2853,7 @@ mod tests {
                 coordinator.state.add_to_queue(
                     contributor.clone(),
                     Some(*contributor_ip),
-                    String::from("irrelevant_token"),
+                    String::from("irrelevant_token"), // No check will be done on this token
                     10,
                     coordinator.time.as_ref(),
                 )?;

--- a/phase1-coordinator/src/coordinator_state.rs
+++ b/phase1-coordinator/src/coordinator_state.rs
@@ -944,7 +944,7 @@ impl Default for RoundMetrics {
 
 /// A temporary runtime state holding values which are specific to the current ceremony run. This state must not be persisted to 
 /// storage to allow a reset of it in case of a ceremony restart
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 struct TmpState {
     /// The list of valid tokens for each cohort
     tokens: Vec<HashSet<String>>,
@@ -956,6 +956,7 @@ struct TmpState {
 
 impl Default for TmpState {
     fn default() -> Self {
+        // Called when deserializing CoordinatorState from file
         // Read tokens from files
         Self { tokens: CoordinatorState::load_tokens(), tokens_in_use: Default::default(), current_ips: Default::default() }
     }
@@ -1001,10 +1002,9 @@ pub struct CoordinatorState {
     /// Map of tokens which have been used in the ceremony
     blacklisted_tokens: HashMap<String, Participant>,
     /// Temporary runtime state, should not be persisted to storage to reset it in case of restart
-    #[serde(skip_serializing)]
+    #[serde(skip)]
     tmp_state: TmpState
 }
-// FIXME: add test for temp state reload
 
 impl CoordinatorState {
     /// Reads tokens from disk and generates a vector of them. Expects tokens to be in a separate folder containing only those files.
@@ -1738,7 +1738,7 @@ impl CoordinatorState {
         &mut self,
         participant: Participant,
         participant_ip: Option<IpAddr>,
-        token: String, //FIXME: optional for contributors only?
+        token: String,
         reliability_score: u8,
         time: &dyn TimeSource,
     ) -> Result<(), CoordinatorError> {

--- a/phase1-coordinator/src/coordinator_state.rs
+++ b/phase1-coordinator/src/coordinator_state.rs
@@ -9,6 +9,7 @@ use crate::{
     TimeSource,
 };
 use lazy_static::lazy_static;
+use anyhow::anyhow;
 
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -23,8 +24,7 @@ use tracing::*;
 lazy_static! {
     static ref IP_BAN: bool = match std::env::var("NAMADA_MPC_IP_BAN") {
         Ok(s) if s == "true" => true,
-        Ok(_) => false,
-        Err(_) => false,
+        _ => false,
     };
     pub static ref TOKENS_PATH: String = std::env::var("NAMADA_TOKENS_PATH").unwrap_or_else(|_| "./tokens".to_string());
 }
@@ -942,20 +942,22 @@ impl Default for RoundMetrics {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub enum TokenState {
-    Available,
-    InUse,
-    Used,
+/// A temporary runtime state holding values which are specific to the current ceremony run. This state must not be persisted to 
+/// storage to allow a reset of it in case of a ceremony restart
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct TmpState { //FIXME: references?
+    /// The list of valid tokens for each cohort
+    tokens: Vec<HashSet<String>>,
+    /// The map of tokens currently in ceremony
+    tokens_in_use: HashMap<String, Participant>,
+    /// The map of ip addresses currently in ceremony
+    current_ips: HashMap<IpAddr, Participant>
 }
 
-impl TokenState {
-    /// Returns true if the token is currently in use or has been already used
-    fn is_blacklisted(&self) -> bool {
-        match self {
-            TokenState::Available => false,
-            _ => true
-        }
+impl Default for TmpState {
+    fn default() -> Self {
+        // Read tokens from files
+        Self { tokens: CoordinatorState::load_tokens(), tokens_in_use: Default::default(), current_ips: Default::default() }
     }
 }
 
@@ -977,7 +979,7 @@ pub struct CoordinatorState {
     /// The map of unique contributors for the current round.
     current_contributors: HashMap<Participant, ParticipantInfo>,
     /// The map of contributors' IPs
-    contributors_ips: HashMap<IpAddr, Participant>,
+    blacklisted_ips: HashMap<IpAddr, Participant>,
     /// The map of unique verifiers for the current round.
     current_verifiers: HashMap<Participant, ParticipantInfo>,
     /// The map of tasks pending verification in the current round.
@@ -996,26 +998,30 @@ pub struct CoordinatorState {
     ceremony_start_time: OffsetDateTime,
     /// Duration, in seconds, of each cohort
     cohort_duration: u64,
-    /// The list of valid tokens for each cohort.
-    tokens: Vec<HashMap<String, (Participant, TokenState)>>,
+    /// Map of tokens which have been used in the ceremony
+    blacklisted_tokens: HashMap<String, Participant>,
+    /// Temporary runtime state, should not be persisted to storage to reset it in case of restart
+    #[serde(skip_serializing)]
+    tmp_state: TmpState
 }
+// FIXME: add test for temp state reload
 
 impl CoordinatorState {
     /// Reads tokens from disk and generates a vector of them. Expects tokens to be in a separate folder containing only those files.
     ///
     /// # Panics
     /// If folder, file names or content don't respect the specified format.
-    pub(super) fn load_tokens() -> Vec<HashMap<String, (Participant, TokenState)>> {
+    pub(super) fn load_tokens() -> Vec<HashSet<String>> {
         let tokens_file_prefix = std::env::var("TOKENS_FILE_PREFIX").unwrap_or("namada_tokens_cohort".to_string());
         let tokens_dir =
             std::fs::read_dir(TOKENS_PATH.as_str()).expect(format!("Error with path {}", &*TOKENS_PATH).as_str());
         let number_of_cohorts = tokens_dir.count();
-        let mut tokens = vec![HashMap::default(); number_of_cohorts];
+        let mut tokens = vec![HashSet::default(); number_of_cohorts];
 
         for cohort in 1..=number_of_cohorts {
             let path = format!("{}/{}_{}.json", *TOKENS_PATH, tokens_file_prefix, cohort);
             let file = std::fs::read(path).unwrap();
-            let token_set: HashMap<String, (Participant, TokenState)> = serde_json::from_slice(&file).unwrap(); //FIXME: does this work?
+            let token_set: HashSet<String> = serde_json::from_slice(&file).unwrap();
             tokens[cohort - 1] = token_set;
         }
 
@@ -1026,14 +1032,14 @@ impl CoordinatorState {
     ///
     /// # Panics
     /// If the files' name don't respect the expected format of if the bytes don't represent a valid HashSet<String>
-    pub(super) fn load_tokens_from_bytes(cohorts: &HashMap<String, Vec<u8>>) -> Vec<HashMap<String, (Participant, TokenState)>> {
-        let mut tokens = vec![HashMap::default(); cohorts.len()];
+    pub(super) fn load_tokens_from_bytes(cohorts: &HashMap<String, Vec<u8>>) -> Vec<HashSet<String>> {
+        let mut tokens = vec![HashSet::default(); cohorts.len()];
 
         for (file_name, bytes) in cohorts {
             let split: Vec<&str> = file_name.rsplit(".json").collect();
             let index_str = split[1].rsplit("_").collect::<Vec<&str>>()[0];
             let index = index_str.parse::<usize>().unwrap() - 1;
-            let token: HashMap<String, (Participant, TokenState)> = serde_json::from_slice(bytes.as_ref()).unwrap(); //FIXME: does this work on file?
+            let token: HashSet<String> = serde_json::from_slice(bytes.as_ref()).unwrap();
             tokens[index] = token;
         }
 
@@ -1043,8 +1049,8 @@ impl CoordinatorState {
     ///
     /// Updates the set of tokens for the ceremony
     ///
-    pub(super) fn update_tokens(&mut self, tokens: Vec<HashMap<String, (Participant, TokenState)>>) {
-        self.tokens = tokens
+    pub(super) fn update_tokens(&mut self, tokens: Vec<HashSet<String>>) {
+        self.tmp_state.tokens = tokens
     }
 
     fn get_ceremony_start_time() -> OffsetDateTime {
@@ -1060,12 +1066,6 @@ impl CoordinatorState {
         ceremony_start_time
     }
 
-    pub(crate) fn is_token_blacklisted(&self, cohort: usize, token: &str) -> Result<bool, CoordinatorError> {
-        let (_, token_state) = self.tokens.get(cohort).ok_or(CoordinatorError::CeremonyIsOver)?.get(token).ok_or(CoordinatorError::Error("Token not found"))?;
-
-        Ok(token_state.is_blacklisted())
-    }
-
     ///
     /// Creates a new instance of `CoordinatorState`.
     ///
@@ -1078,14 +1078,13 @@ impl CoordinatorState {
     #[inline]
     pub(super) fn new(
         environment: Environment,
-        ceremony_start_time: Option<OffsetDateTime>,
-        cohort_duration: Option<u64>,
-        tokens: Option<Vec<HashMap<String, (Participant, TokenState)>>>,
     ) -> Self {
-        let cohort_duration = cohort_duration.unwrap_or_else(|| match std::env::var("NAMADA_COHORT_TIME") {
+        let cohort_duration = match std::env::var("NAMADA_COHORT_TIME") {
             Ok(n) => n.parse::<u64>().unwrap(),
             Err(_) => 86400,
-        });
+        };
+
+        let ceremony_start_time = CoordinatorState::get_ceremony_start_time();
 
         Self {
             environment,
@@ -1095,7 +1094,7 @@ impl CoordinatorState {
             current_metrics: None,
             current_round_height: None,
             current_contributors: HashMap::default(),
-            contributors_ips: HashMap::default(),
+            blacklisted_ips: HashMap::default(),
             current_verifiers: HashMap::default(),
             pending_verification: HashMap::default(),
             finished_contributors: HashMap::default(),
@@ -1103,9 +1102,10 @@ impl CoordinatorState {
             dropped: Vec::new(),
             banned: HashSet::new(),
             manual_lock: false,
-            ceremony_start_time: ceremony_start_time.unwrap_or_else(CoordinatorState::get_ceremony_start_time),
+            ceremony_start_time,
             cohort_duration,
-            tokens: tokens.unwrap_or_else(CoordinatorState::load_tokens),
+            blacklisted_tokens: HashMap::default(),
+            tmp_state: TmpState::default()
         }
     }
 
@@ -1209,16 +1209,17 @@ impl CoordinatorState {
             }
 
             *self = Self {
+                ceremony_start_time: std::mem::replace(&mut self.ceremony_start_time, OffsetDateTime::now_utc()),
+                cohort_duration: std::mem::take(&mut self.cohort_duration),
                 current_metrics,
                 current_round_height: Some(new_round_height),
-                contributors_ips: std::mem::take(&mut self.contributors_ips),
+                blacklisted_ips: std::mem::take(&mut self.blacklisted_ips),
                 queue,
                 banned: std::mem::take(&mut self.banned),
+                blacklisted_tokens: std::mem::take(&mut self.blacklisted_tokens),
+                tmp_state: std::mem::take(&mut self.tmp_state),
                 ..Self::new(
                     self.environment.clone(),
-                    Some(self.ceremony_start_time),
-                    Some(self.cohort_duration),
-                    Some(std::mem::take(&mut self.tokens)),
                 )
             };
 
@@ -1255,17 +1256,18 @@ impl CoordinatorState {
             // Will reset the round to run with the remaining participants.
 
             *self = Self {
+                ceremony_start_time: std::mem::replace(&mut self.ceremony_start_time, OffsetDateTime::now_utc()),
+                cohort_duration: std::mem::take(&mut self.cohort_duration),
                 current_contributors,
                 current_verifiers: Default::default(),
-                contributors_ips: std::mem::take(&mut self.contributors_ips),
+                blacklisted_ips: std::mem::take(&mut self.blacklisted_ips),
                 queue: std::mem::take(&mut self.queue),
                 banned: std::mem::take(&mut self.banned),
                 dropped: std::mem::take(&mut self.dropped),
+                blacklisted_tokens: std::mem::take(&mut self.blacklisted_tokens),
+                tmp_state: std::mem::take(&mut self.tmp_state),
                 ..Self::new(
                     self.environment.clone(),
-                    Some(self.ceremony_start_time),
-                    Some(self.cohort_duration),
-                    Some(std::mem::take(&mut self.tokens)),
                 )
             };
 
@@ -1307,13 +1309,6 @@ impl CoordinatorState {
 
         // Set the status to initialized.
         self.status = CoordinatorStatus::Initialized;
-    }
-
-    ///
-    /// Returns `true` if a contributor Ip is already known
-    ///
-    pub fn is_duplicate_ip(&self, ip: &IpAddr) -> bool {
-        self.contributors_ips.contains_key(ip)
     }
 
     ///
@@ -1505,15 +1500,53 @@ impl CoordinatorState {
     ///
     #[inline]
     pub(super) fn get_number_of_cohorts(&self) -> usize {
-        self.tokens.len()
+        self.tmp_state.tokens.len()
     }
 
     ///
     /// Returns the list of valid tokens for a given cohort.
     ///
     #[inline]
-    pub fn tokens(&self, cohort: usize) -> Option<&HashMap<String, (Participant, TokenState)>> {
-        self.tokens.get(cohort)
+    pub fn tokens(&self, cohort: usize) -> Option<&HashSet<String>> {
+        self.tmp_state.tokens.get(cohort)
+    }
+
+    ///
+    /// Moves the ip address and token from the list of currently in use to the black lists
+    /// 
+    pub fn blacklist_participant(&mut self, participant: &Participant) -> Result<(), CoordinatorError> { //FIXME: are errors propagated and do they shut the server down? They should
+        // Blacklist token
+        let (target_token, _) = self.tmp_state.tokens_in_use.iter().find(|(_, part)| *part == participant).ok_or(CoordinatorError::Error(anyhow!("Missing token for participant {}", participant)))?;
+
+        self.tmp_state.tokens_in_use.remove(target_token);
+        if let Some(part) = self.blacklisted_tokens.insert(target_token.clone(), participant.clone()) {
+            return Err(CoordinatorError::Error(anyhow!("Token {} was already blacklisted for participant {}!", target_token, part)));
+        }
+
+        // Blacklist Ip address
+        if let Some((target_ip, _)) = self.tmp_state.current_ips.iter().find(|(_, part)| *part == participant) {
+            self.tmp_state.current_ips.remove(target_ip);
+
+            if let Some(part) = self.blacklisted_ips.insert(target_ip.clone(), participant.clone()) {
+                return Err(CoordinatorError::Error(anyhow!("Ip {} was already blacklisted for participant {}!", target_ip, part)));
+            }
+        }
+
+        Ok(())
+    }
+
+    ///
+    /// Returns true if the token is currently in use
+    /// 
+    pub fn is_token_in_use(&self, token: &str) -> bool {
+        self.tmp_state.tokens_in_use.contains_key(token)
+    }
+
+    ///
+    /// Returns true if the token has been blacklisted
+    /// 
+    pub fn is_token_blacklisted(&self, token: &str) -> bool {
+        self.blacklisted_tokens.contains_key(token)
     }
 
     ///
@@ -1645,7 +1678,7 @@ impl CoordinatorState {
     ) -> Result<(), CoordinatorError> {
         // Check that the pariticipant IP is not known.
         if let Some(ip) = participant_ip {
-            if *IP_BAN && self.is_duplicate_ip(ip) {
+            if *IP_BAN && (self.blacklisted_ips.contains_key(ip) || self.tmp_state.current_ips.contains_key(ip)) {
                 return Err(CoordinatorError::ParticipantIpAlreadyAdded);
             }
         }
@@ -1702,6 +1735,7 @@ impl CoordinatorState {
         &mut self,
         participant: Participant,
         participant_ip: Option<IpAddr>,
+        token: String, //FIXME: optional for contributors only?
         reliability_score: u8,
         time: &dyn TimeSource,
     ) -> Result<(), CoordinatorError> {
@@ -1712,10 +1746,13 @@ impl CoordinatorState {
             (reliability_score, None, time.now_utc(), time.now_utc()),
         );
 
-        // Add ip (if any) to the set of known addresses
+        // Add ip (if any) to the set of currently known addresses
         if let Some(ip) = participant_ip {
-            self.contributors_ips.insert(ip, participant);
+            self.tmp_state.current_ips.insert(ip, participant.clone());
         }
+
+        // Add token to the set of currenly known ones
+        self.tmp_state.tokens_in_use.insert(token, participant);
 
         Ok(())
     }
@@ -2273,6 +2310,15 @@ impl CoordinatorState {
 
         warn!("Dropping {} from the ceremony", participant);
 
+        // Remove temporary state if participant is a contributor
+        if let Participant::Contributor(_) = participant {
+            // Remove ip (if any) from the list of current ips to allow the participant to rejoin
+            self.tmp_state.current_ips = self.tmp_state.current_ips.drain().filter(|(_, contributor)| contributor != participant).collect();
+
+            // Remove token from the list of current tokens
+            self.tmp_state.tokens_in_use = self.tmp_state.tokens_in_use.drain().filter(|(_, contributor)| contributor != participant).collect();
+        }
+
         // Remove the participant from the queue and precommit, if present.
         if self.queue.contains_key(participant) || self.next.contains_key(participant) {
             // Remove the participant from the queue.
@@ -2287,24 +2333,6 @@ impl CoordinatorState {
                 self.next.remove(participant);
                 // Trigger a rollback as the precommit has changed.
                 self.rollback_next_round(time);
-            }
-
-            // Remove ip (if any) from the list of current ips to allow the participant to rejoin
-            self.contributors_ips = self
-                .contributors_ips
-                .drain()
-                .filter(|(_, contributor)| contributor != participant)
-                .collect();
-
-            // Reset token state to available
-            // Need to cycle over all the cohorts because a user may join the queue at the very last moment of a cohort, effectively contributing in the following cohort
-            'outer: for map in self.tokens.iter_mut() {
-                for (_, (part, token)) in map {
-                    if part == participant {
-                        *token = TokenState::Available;
-                        break 'outer;
-                    }
-                }
             }
 
             return Ok(DropParticipant::DropQueue(DropQueueParticipantData {
@@ -2534,26 +2562,14 @@ impl CoordinatorState {
             return Err(CoordinatorError::ParticipantAlreadyBanned);
         }
 
-        // Save participant ip for later ban
-        let participant_ip = match self
-            .contributors_ips
-            .iter()
-            .filter(|(_, contributor)| *contributor == participant)
-            .next()
-        {
-            Some((ip, contrib)) => Some((ip.clone(), contrib.clone())),
-            None => None,
-        };
+        // NOTE: Ip address and token have already been blacklisted when the contribution has been updated (try_contribute)
+        // Ban of a participant can only happen aftwerwards (during contribution verification), so no actions needed here
 
         // Drop the participant from the queue, precommit, and current round.
         let drop = self.drop_participant(participant, time)?;
 
         // Add the participant to the banned list.
         self.banned.insert(participant.clone());
-        // Ban contributor's ip, if any
-        if let Some((ip, participant)) = participant_ip {
-            self.contributors_ips.insert(ip, participant);
-        }
 
         // NOTE: token of the participant has already been blacklisted at the end of the contribution, no need to take actions here
 
@@ -2576,8 +2592,8 @@ impl CoordinatorState {
             .collect();
 
         // Unban ip
-        self.contributors_ips = self
-            .contributors_ips
+        self.blacklisted_ips = self
+            .blacklisted_ips
             .drain()
             .filter(|(_, contributor)| contributor != participant)
             .collect();
@@ -3568,7 +3584,7 @@ mod tests {
     #[test]
     fn test_new() {
         // Initialize a new coordinator state.
-        let state = CoordinatorState::new(TEST_ENVIRONMENT.clone(), None, None, None);
+        let state = CoordinatorState::new(TEST_ENVIRONMENT.clone());
         assert_eq!(0, state.queue.len());
         assert_eq!(0, state.next.len());
         assert_eq!(None, state.current_round_height);
@@ -3584,7 +3600,7 @@ mod tests {
     #[test]
     fn test_set_current_round_height() {
         // Initialize a new coordinator state.
-        let mut state = CoordinatorState::new(TEST_ENVIRONMENT.clone(), None, None, None);
+        let mut state = CoordinatorState::new(TEST_ENVIRONMENT.clone());
         assert_eq!(None, state.current_round_height);
 
         // Set the current round height for coordinator state.
@@ -3601,15 +3617,17 @@ mod tests {
         // Fetch the contributor of the coordinator.
         let contributor = test_coordinator_contributor(&environment).unwrap();
         let contributor_ip = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
+        let token = String::from("test_token");
+        let token2 = String::from("test_token_2");
         assert!(contributor.is_contributor());
 
         // Initialize a new coordinator state.
-        let mut state = CoordinatorState::new(environment.clone(), None, None, None);
+        let mut state = CoordinatorState::new(environment.clone());
         assert_eq!(0, state.queue.len());
 
         // Add the contributor of the coordinator.
         state
-            .add_to_queue(contributor.clone(), Some(contributor_ip), 10, &time)
+            .add_to_queue(contributor.clone(), Some(contributor_ip), token, 10, &time)
             .unwrap();
         assert_eq!(1, state.queue.len());
         assert_eq!(0, state.next.len());
@@ -3629,7 +3647,7 @@ mod tests {
 
         // Attempt to add the contributor again.
         for _ in 0..10 {
-            let result = state.add_to_queue(contributor.clone(), Some(contributor_ip), 10, &time);
+            let result = state.add_to_queue(contributor.clone(), Some(contributor_ip), token2.clone(), 10, &time);
             assert!(result.is_err());
             assert_eq!(1, state.queue.len());
         }
@@ -3646,9 +3664,11 @@ mod tests {
         // To be used by both contributors.
         let contributor_ip = IpAddr::V4(Ipv4Addr::LOCALHOST);
         assert!(contributor_1.is_contributor());
+        let token = String::from("test_token");
+        let token2 = String::from("test_token_2");
 
         // Initialize a new coordinator state.
-        let mut state = CoordinatorState::new(environment.clone(), None, None, None);
+        let mut state = CoordinatorState::new(environment.clone());
         let current_round_height = 5;
         state.initialize(current_round_height);
         assert!(state.queue.is_empty());
@@ -3656,13 +3676,13 @@ mod tests {
 
         // Add the contributors to the coordinator queue.
         state
-            .add_to_queue(contributor_1.clone(), Some(contributor_ip), 10, &time)
+            .add_to_queue(contributor_1.clone(), Some(contributor_ip), token, 10, &time)
             .unwrap();
         assert_eq!(1, state.queue.len());
 
         // Add the second contributor with the same ip.
         state
-            .add_to_queue(contributor_2.clone(), Some(contributor_ip), 10, &time)
+            .add_to_queue(contributor_2.clone(), Some(contributor_ip), token2, 10, &time)
             .unwrap();
         assert_eq!(2, state.queue.len());
 
@@ -3676,13 +3696,13 @@ mod tests {
         state.drop_participant(&contributor_1, &time).unwrap();
 
         // Verify the IP still exists as one participant associated with it is left in the queue.
-        assert!(state.contributors_ips.contains_key(&contributor_ip));
+        assert!(state.blacklisted_ips.contains_key(&contributor_ip));
 
         // Drop the second participant.
         state.drop_participant(&contributor_2, &time).unwrap();
 
         // Verify the IP has been deleted.
-        assert!(!state.contributors_ips.contains_key(&contributor_ip));
+        assert!(!state.blacklisted_ips.contains_key(&contributor_ip));
     }
 
     #[test]
@@ -3693,13 +3713,15 @@ mod tests {
         // Fetch the verifier of the coordinator.
         let verifier = test_coordinator_verifier(&environment).unwrap();
         assert!(verifier.is_verifier());
+        let token = String::from("test_token");
+        let token2 = String::from("test_token_2");
 
         // Initialize a new coordinator state.
-        let mut state = CoordinatorState::new(environment.clone(), None, None, None);
+        let mut state = CoordinatorState::new(environment.clone());
         assert_eq!(0, state.queue.len());
 
         // Add the verifier of the coordinator.
-        let result = state.add_to_queue(verifier.clone(), None, 10, &time);
+        let result = state.add_to_queue(verifier.clone(), None, token, 10, &time);
         assert!(result.is_err());
         assert_eq!(0, state.queue.len());
         assert_eq!(0, state.next.len());
@@ -3718,7 +3740,7 @@ mod tests {
 
         // Attempt to add the verifier again.
         for _ in 0..10 {
-            let result = state.add_to_queue(verifier.clone(), None, 10, &time);
+            let result = state.add_to_queue(verifier.clone(), None, token2.clone(), 10, &time);
             assert!(result.is_err());
             assert_eq!(0, state.queue.len());
         }
@@ -3732,9 +3754,11 @@ mod tests {
         // Fetch the contributor and verifier of the coordinator.
         let contributor = test_coordinator_contributor(&environment).unwrap();
         let contributor_ip = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
+        let token = String::from("test_token");
+        let token2 = String::from("test_token_2");
 
         // Initialize a new coordinator state.
-        let mut state = CoordinatorState::new(environment.clone(), None, None, None);
+        let mut state = CoordinatorState::new(environment.clone());
         assert_eq!(0, state.queue.len());
         assert_eq!(None, state.current_round_height);
 
@@ -3746,7 +3770,7 @@ mod tests {
 
         // Add the contributor and verifier of the coordinator.
         state
-            .add_to_queue(contributor.clone(), Some(contributor_ip), 10, &time)
+            .add_to_queue(contributor.clone(), Some(contributor_ip), token, 10, &time)
             .unwrap();
         assert_eq!(1, state.queue.len());
         assert_eq!(0, state.next.len());
@@ -3777,7 +3801,7 @@ mod tests {
 
         // Attempt to add the contributor and verifier again.
         for _ in 0..10 {
-            let contributor_result = state.add_to_queue(contributor.clone(), Some(contributor_ip), 10, &time);
+            let contributor_result = state.add_to_queue(contributor.clone(), Some(contributor_ip), token2.clone(), 10, &time);
             assert!(contributor_result.is_err());
             assert_eq!(1, state.queue.len());
         }
@@ -3789,7 +3813,7 @@ mod tests {
         let environment = TEST_ENVIRONMENT.clone();
 
         // Initialize a new coordinator state.
-        let mut state = CoordinatorState::new(environment.clone(), None, None, None);
+        let mut state = CoordinatorState::new(environment.clone());
         assert_eq!(0, state.queue.len());
         assert_eq!(None, state.current_round_height);
 
@@ -3804,6 +3828,7 @@ mod tests {
         let number_of_contributors_in_queue = 2 * maximum_contributors_per_round;
         for id in 1..=number_of_contributors_in_queue {
             trace!("Adding contributor with ID {}", id);
+            let token = format!("test_token_{}", id);
 
             // Add a unique contributor.
             let contributor = Participant::Contributor(id.to_string());
@@ -3811,7 +3836,7 @@ mod tests {
 
             let reliability = 10 - id as u8;
             state
-                .add_to_queue(contributor.clone(), Some(contributor_ip), reliability, &time)
+                .add_to_queue(contributor.clone(), Some(contributor_ip), token, reliability, &time)
                 .unwrap();
             assert_eq!(id, state.queue.len());
             assert_eq!(0, state.next.len());
@@ -3863,14 +3888,15 @@ mod tests {
         // Fetch the contributor of the coordinator.
         let contributor = test_coordinator_contributor(&environment).unwrap();
         let contributor_ip = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
+        let token = String::from("test_token");
 
         // Initialize a new coordinator state.
-        let mut state = CoordinatorState::new(environment.clone(), None, None, None);
+        let mut state = CoordinatorState::new(environment.clone());
         assert_eq!(0, state.queue.len());
 
         // Add the contributor of the coordinator.
         state
-            .add_to_queue(contributor.clone(), Some(contributor_ip), 10, &time)
+            .add_to_queue(contributor.clone(), Some(contributor_ip), token, 10, &time)
             .unwrap();
         assert_eq!(1, state.queue.len());
         assert_eq!(0, state.next.len());
@@ -3904,9 +3930,10 @@ mod tests {
         // Fetch the contributor and verifier of the coordinator.
         let contributor = test_coordinator_contributor(&environment).unwrap();
         let contributor_ip = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
+        let token = String::from("test_token");
 
         // Initialize a new coordinator state.
-        let mut state = CoordinatorState::new(environment.clone(), None, None, None);
+        let mut state = CoordinatorState::new(environment.clone());
         assert_eq!(0, state.queue.len());
         assert_eq!(None, state.current_round_height);
 
@@ -3918,7 +3945,7 @@ mod tests {
 
         // Add the contributor and verifier of the coordinator.
         state
-            .add_to_queue(contributor.clone(), Some(contributor_ip), 10, &time)
+            .add_to_queue(contributor.clone(), Some(contributor_ip), token, 10, &time)
             .unwrap();
         assert_eq!(1, state.queue.len());
 
@@ -3997,9 +4024,10 @@ mod tests {
         // Fetch the contributor and verifier of the coordinator.
         let contributor = test_coordinator_contributor(&environment).unwrap();
         let contributor_ip = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
+        let token = String::from("test_token");
 
         // Initialize a new coordinator state.
-        let mut state = CoordinatorState::new(environment.clone(), None, None, None);
+        let mut state = CoordinatorState::new(environment.clone());
         assert_eq!(0, state.queue.len());
         assert_eq!(None, state.current_round_height);
 
@@ -4011,7 +4039,7 @@ mod tests {
 
         // Add the contributor and verifier of the coordinator.
         state
-            .add_to_queue(contributor.clone(), Some(contributor_ip), 10, &time)
+            .add_to_queue(contributor.clone(), Some(contributor_ip), token, 10, &time)
             .unwrap();
         assert_eq!(1, state.queue.len());
 
@@ -4086,13 +4114,14 @@ mod tests {
         // Fetch the contributor and verifier of the coordinator.
         let contributor = test_coordinator_contributor(&environment).unwrap();
         let contributor_ip = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
+        let token = String::from("test_token");
 
         // Initialize a new coordinator state.
         let current_round_height = 5;
-        let mut state = CoordinatorState::new(environment.clone(), None, None, None);
+        let mut state = CoordinatorState::new(environment.clone());
         state.initialize(current_round_height);
         state
-            .add_to_queue(contributor.clone(), Some(contributor_ip), 10, &time)
+            .add_to_queue(contributor.clone(), Some(contributor_ip), token, 10, &time)
             .unwrap();
         state.update_queue().unwrap();
         state.aggregating_current_round(&time).unwrap();
@@ -4150,13 +4179,14 @@ mod tests {
         let contributor = test_coordinator_contributor(&environment).unwrap();
         let contributor_ip = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
         let verifier = test_coordinator_verifier(&environment).unwrap();
+        let token = String::from("test_token");
 
         // Initialize a new coordinator state.
         let current_round_height = 5;
-        let mut state = CoordinatorState::new(environment.clone(), None, None, None);
+        let mut state = CoordinatorState::new(environment.clone());
         state.initialize(current_round_height);
         state
-            .add_to_queue(contributor.clone(), Some(contributor_ip), 10, &time)
+            .add_to_queue(contributor.clone(), Some(contributor_ip), token, 10, &time)
             .unwrap();
         state.update_queue().unwrap();
         state.aggregating_current_round(&time).unwrap();
@@ -4232,16 +4262,18 @@ mod tests {
         let contributor_2 = TEST_CONTRIBUTOR_ID_2.clone();
         let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
         let verifier = TEST_VERIFIER_ID.clone();
+        let token = String::from("test_token");
+        let token2 = String::from("test_token_2");
 
         // Initialize a new coordinator state.
         let current_round_height = 5;
-        let mut state = CoordinatorState::new(environment.clone(), None, None, None);
+        let mut state = CoordinatorState::new(environment.clone());
         state.initialize(current_round_height);
         state
-            .add_to_queue(contributor_1.clone(), Some(contributor_1_ip), 10, &time)
+            .add_to_queue(contributor_1.clone(), Some(contributor_1_ip), token, 10, &time)
             .unwrap();
         state
-            .add_to_queue(contributor_2.clone(), Some(contributor_2_ip), 9, &time)
+            .add_to_queue(contributor_2.clone(), Some(contributor_2_ip), token2, 9, &time)
             .unwrap();
         state.update_queue().unwrap();
         state.aggregating_current_round(&time).unwrap();
@@ -4347,16 +4379,18 @@ mod tests {
         let contributor_2 = TEST_CONTRIBUTOR_ID_2.clone();
         let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
         let verifier_1 = TEST_VERIFIER_ID.clone();
+        let token = String::from("test_token");
+        let token2 = String::from("test_token_2");
 
         // Initialize a new coordinator state.
         let current_round_height = 5;
-        let mut state = CoordinatorState::new(environment.clone(), None, None, None);
+        let mut state = CoordinatorState::new(environment.clone());
         state.initialize(current_round_height);
         state
-            .add_to_queue(contributor_1.clone(), Some(contributor_1_ip), 10, &time)
+            .add_to_queue(contributor_1.clone(), Some(contributor_1_ip), token, 10, &time)
             .unwrap();
         state
-            .add_to_queue(contributor_2.clone(), Some(contributor_2_ip), 9, &time)
+            .add_to_queue(contributor_2.clone(), Some(contributor_2_ip), token2, 9, &time)
             .unwrap();
         state.update_queue().unwrap();
         state.aggregating_current_round(&time).unwrap();
@@ -4494,16 +4528,18 @@ mod tests {
         let contributor_2 = TEST_CONTRIBUTOR_ID_2.clone();
         let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
         let verifier_1 = TEST_VERIFIER_ID.clone();
+        let token = String::from("test_token");
+        let token2 = String::from("test_token_2");
 
         // Initialize a new coordinator state.
         let current_round_height = 5;
-        let mut state = CoordinatorState::new(environment.clone(), None, None, None);
+        let mut state = CoordinatorState::new(environment.clone());
         state.initialize(current_round_height);
         state
-            .add_to_queue(contributor_1.clone(), Some(contributor_1_ip), 10, &time)
+            .add_to_queue(contributor_1.clone(), Some(contributor_1_ip), token, 10, &time)
             .unwrap();
         state
-            .add_to_queue(contributor_2.clone(), Some(contributor_2_ip), 9, &time)
+            .add_to_queue(contributor_2.clone(), Some(contributor_2_ip), token2, 9, &time)
             .unwrap();
         state.update_queue().unwrap();
         state.aggregating_current_round(&time).unwrap();
@@ -4654,16 +4690,18 @@ mod tests {
         let contributor_2 = TEST_CONTRIBUTOR_ID_2.clone();
         let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
         let verifier_1 = TEST_VERIFIER_ID.clone();
+        let token = String::from("test_token");
+        let token2 = String::from("test_token_2");
 
         // Initialize a new coordinator state.
         let current_round_height = 5;
-        let mut state = CoordinatorState::new(environment.clone(), None, None, None);
+        let mut state = CoordinatorState::new(environment.clone());
         state.initialize(current_round_height);
         state
-            .add_to_queue(contributor_1.clone(), Some(contributor_1_ip), 10, &time)
+            .add_to_queue(contributor_1.clone(), Some(contributor_1_ip), token, 10, &time)
             .unwrap();
         state
-            .add_to_queue(contributor_2.clone(), Some(contributor_2_ip), 9, &time)
+            .add_to_queue(contributor_2.clone(), Some(contributor_2_ip), token2, 9, &time)
             .unwrap();
         state.update_queue().unwrap();
         state.aggregating_current_round(&time).unwrap();
@@ -4806,13 +4844,14 @@ mod tests {
         let contributor_1 = TEST_CONTRIBUTOR_ID.clone();
         let contributor_1_ip = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
         let verifier_1 = TEST_VERIFIER_ID.clone();
+        let token = String::from("test_token");
 
         // Initialize a new coordinator state.
         let current_round_height = 5;
-        let mut state = CoordinatorState::new(environment.clone(), None, None, None);
+        let mut state = CoordinatorState::new(environment.clone());
         state.initialize(current_round_height);
         state
-            .add_to_queue(contributor_1.clone(), Some(contributor_1_ip), 10, &time)
+            .add_to_queue(contributor_1.clone(), Some(contributor_1_ip), token, 10, &time)
             .unwrap();
         state.update_queue().unwrap();
         state.aggregating_current_round(&time).unwrap();

--- a/phase1-coordinator/src/main.rs
+++ b/phase1-coordinator/src/main.rs
@@ -181,7 +181,8 @@ pub async fn main() {
         "NAMADA_TOKENS_PATH",
         "CEREMONY_START_TIMESTAMP",
         "TOKENS_FILE_PREFIX",
-        "NAMADA_COHORT_TIME"
+        "NAMADA_COHORT_TIME",
+        "TOKEN_BLACKLIST"
     );
 
     // Generate, publish and export the secret token
@@ -202,10 +203,8 @@ pub async fn main() {
     #[cfg(not(debug_assertions))]
     let environment: Production = { Production::new(&keypair) };
 
-    // Download token file from S3, only if local folder is missing
-    if std::fs::metadata(TOKENS_PATH.as_str()).is_err() {
-        download_tokens().await.expect("Error while retrieving tokens");
-    }
+    // Always download token files from S3 to check for updates
+    download_tokens().await.expect("Error while retrieving tokens");
 
     // Initialize the coordinator
     let coordinator =
@@ -381,3 +380,5 @@ pub async fn main() {
         }
     }
 }
+
+// FIXME: add unit and e2e tests for token blacklisting

--- a/phase1-coordinator/src/main.rs
+++ b/phase1-coordinator/src/main.rs
@@ -380,6 +380,3 @@ pub async fn main() {
         }
     }
 }
-
-// FIXME: add unit and e2e tests for token blacklisting
-// FIXME: add test for temp state reload

--- a/phase1-coordinator/src/main.rs
+++ b/phase1-coordinator/src/main.rs
@@ -382,3 +382,4 @@ pub async fn main() {
 }
 
 // FIXME: add unit and e2e tests for token blacklisting
+// FIXME: add test for temp state reload

--- a/phase1-coordinator/src/rest.rs
+++ b/phase1-coordinator/src/rest.rs
@@ -341,7 +341,6 @@ pub async fn post_contribution_info(
 }
 
 /// Retrieve the contributions' info. This endpoint is accessible by anyone and does not require a signed request.
-/// FIXME: should state json as return fomrat? Why returns a file?
 #[get("/contribution_info")]
 pub async fn get_contributions_info(coordinator: &State<Coordinator>) -> Result<Vec<u8>> {
     let read_lock = (*coordinator).clone().read_owned().await;
@@ -353,7 +352,6 @@ pub async fn get_contributions_info(coordinator: &State<Coordinator>) -> Result<
 }
 
 /// Retrieve the coordinator.json status file
-/// /// FIXME: should state json as return fomrat? Why returns a file?
 #[get("/coordinator_status")]
 pub async fn get_coordinator_state(coordinator: &State<Coordinator>, _auth: Secret) -> Result<Vec<u8>> {
     let read_lock = (*coordinator).clone().read_owned().await;

--- a/phase1-coordinator/src/rest.rs
+++ b/phase1-coordinator/src/rest.rs
@@ -52,9 +52,15 @@ pub async fn join_queue(
     let mut write_lock = (*coordinator).clone().write_owned().await;
 
     task::spawn_blocking(move || {
-        write_lock.add_to_queue(new_participant.participant, new_participant.ip_address, token.clone(), 10)
-    }).await?
-        .map_err(|e| ResponseError::CoordinatorError(e)) 
+        write_lock.add_to_queue(
+            new_participant.participant,
+            new_participant.ip_address,
+            token.clone(),
+            10,
+        )
+    })
+    .await?
+    .map_err(|e| ResponseError::CoordinatorError(e))
 }
 
 /// Lock a [Chunk](`crate::objects::Chunk`) in the ceremony. This should be the first function called when attempting to contribute to a chunk. Once the chunk is locked, it is ready to be downloaded.
@@ -216,9 +222,9 @@ pub async fn update_cohorts(
     match new_tokens.get(cohort) {
         Some(new_tokens) => {
             if new_tokens != old_tokens {
-                return Err(ResponseError::InvalidNewTokens)
+                return Err(ResponseError::InvalidNewTokens);
             }
-        },
+        }
         _ => return Err(ResponseError::InvalidNewTokens),
     }
     drop(read_lock);

--- a/phase1-coordinator/src/rest_utils.rs
+++ b/phase1-coordinator/src/rest_utils.rs
@@ -121,6 +121,7 @@ impl<'r> Responder<'r, 'static> for ResponseError {
         let mut builder = Response::build();
 
         let response_code = match self {
+            ResponseError::BlacklistedToken => Status::Unauthorized,
             ResponseError::CeremonyIsOver => Status::Unauthorized,
             ResponseError::InvalidHeader(_) => Status::BadRequest,
             ResponseError::InvalidSecret => Status::Unauthorized,
@@ -132,6 +133,7 @@ impl<'r> Responder<'r, 'static> for ResponseError {
             ResponseError::MissingRequiredHeader(_) => Status::BadRequest,
             ResponseError::MissingSigningKey => Status::BadRequest,
             ResponseError::SerdeError(_) => Status::UnprocessableEntity,
+            ResponseError::TokenAlreadyInUse => Status::Unauthorized,
             ResponseError::UnauthorizedParticipant(_, _, _) => Status::Unauthorized,
             ResponseError::WrongDigestEncoding(_) => Status::BadRequest,
             _ => Status::InternalServerError,

--- a/phase1-coordinator/src/rest_utils.rs
+++ b/phase1-coordinator/src/rest_utils.rs
@@ -607,7 +607,7 @@ impl PostChunkRequest {
 }
 
 /// Checks the validity of the token for the ceremony.
-pub(crate) async fn token_check(coordinator: Coordinator, token: &String) -> Result<()> {
+pub(crate) async fn token_check(coordinator: Coordinator, token: &str) -> Result<()> {
     // Check if the token's format is correct
     let regex = Regex::new(TOKEN_REGEX).unwrap();
 
@@ -623,9 +623,15 @@ pub(crate) async fn token_check(coordinator: Coordinator, token: &String) -> Res
         None => return Err(ResponseError::CeremonyIsOver),
     };
 
-    if !tokens.contains(token) {
+    if !tokens.contains_key(token) {
         return Err(ResponseError::InvalidToken(cohort + 1));
     }
+
+    // FIXME: check token not blacklisted nor in use only if env variable is set
+    if !read_lock.state().is_token_blacklisted(cohort, token)? {
+        return Err(ResponseError::InvalidToken(cohort + 1)); //FIXME: change error, differentiate between blacklist and currently in use
+    }
+
 
     Ok(())
 }

--- a/phase1-coordinator/src/rest_utils.rs
+++ b/phase1-coordinator/src/rest_utils.rs
@@ -38,7 +38,7 @@ pub const UPDATE_TIME: Duration = Duration::from_secs(5);
 pub const UPDATE_TIME: Duration = Duration::from_secs(60);
 
 pub const UNKNOWN: &str = "Unknown";
-pub const TOKEN_REGEX: &str = r"^[A-HJ-NP-Za-km-z1-9]*$";
+pub const TOKEN_REGEX: &str = r"^[A-HJ-NP-Za-km-z1-9]{115}$";
 
 // Headers
 pub const BODY_DIGEST_HEADER: &str = "Digest";

--- a/phase1-coordinator/src/storage/disk.rs
+++ b/phase1-coordinator/src/storage/disk.rs
@@ -58,8 +58,8 @@ impl Disk {
             resolver: DiskResolver::new(environment.local_base_directory()),
         };
 
-         // Create the coordinator state locator if it does not exist yet.
-         if !storage.exists(&Locator::CoordinatorState) {
+        // Create the coordinator state locator if it does not exist yet.
+        if !storage.exists(&Locator::CoordinatorState) {
             storage.insert(
                 Locator::CoordinatorState,
                 Object::CoordinatorState(CoordinatorState::new(environment.clone())),

--- a/phase1-coordinator/src/tests.rs
+++ b/phase1-coordinator/src/tests.rs
@@ -1249,10 +1249,20 @@ fn coordinator_drop_contributor_and_release_locks() {
     let test_contributor_4 = create_contributor_test_details("4");
     let contributor_4_ip = IpAddr::V4("0.0.0.4".parse().unwrap());
     coordinator
-        .add_to_queue(test_contributor_3.participant.clone(), Some(contributor_3_ip), token3, 10)
+        .add_to_queue(
+            test_contributor_3.participant.clone(),
+            Some(contributor_3_ip),
+            token3,
+            10,
+        )
         .unwrap();
     coordinator
-        .add_to_queue(test_contributor_4.participant.clone(), Some(contributor_4_ip), token4, 10)
+        .add_to_queue(
+            test_contributor_4.participant.clone(),
+            Some(contributor_4_ip),
+            token4,
+            10,
+        )
         .unwrap();
 
     // Update the ceremony to round 2.
@@ -1388,10 +1398,20 @@ fn coordinator_drop_several_contributors() {
     let test_contributor_4 = create_contributor_test_details("4");
     let contributor_4_ip = IpAddr::V4("0.0.0.4".parse().unwrap());
     coordinator
-        .add_to_queue(test_contributor_3.participant.clone(), Some(contributor_3_ip), token3, 10)
+        .add_to_queue(
+            test_contributor_3.participant.clone(),
+            Some(contributor_3_ip),
+            token3,
+            10,
+        )
         .unwrap();
     coordinator
-        .add_to_queue(test_contributor_4.participant.clone(), Some(contributor_4_ip), token4, 10)
+        .add_to_queue(
+            test_contributor_4.participant.clone(),
+            Some(contributor_4_ip),
+            token4,
+            10,
+        )
         .unwrap();
 
     // Update the ceremony to round 2.
@@ -1553,10 +1573,20 @@ fn coordinator_drop_contributor_and_update_verifier_tasks() {
     let test_contributor_4 = create_contributor_test_details("4");
     let contributor_4_ip = IpAddr::V4("0.0.0.4".parse().unwrap());
     coordinator
-        .add_to_queue(test_contributor_3.participant.clone(), Some(contributor_3_ip), token3, 10)
+        .add_to_queue(
+            test_contributor_3.participant.clone(),
+            Some(contributor_3_ip),
+            token3,
+            10,
+        )
         .unwrap();
     coordinator
-        .add_to_queue(test_contributor_4.participant.clone(), Some(contributor_4_ip), token4, 10)
+        .add_to_queue(
+            test_contributor_4.participant.clone(),
+            Some(contributor_4_ip),
+            token4,
+            10,
+        )
         .unwrap();
 
     // Update the ceremony to round 2.
@@ -1882,8 +1912,18 @@ fn drop_all_contributors_and_complete_round() -> anyhow::Result<()> {
     let test_contributor_2 = create_contributor_test_details("2");
     let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let (verifier, verifier_signing_key) = create_verifier("1");
-    coordinator.add_to_queue(test_contributor_1.participant.clone(), Some(contributor_1_ip), token, 10)?;
-    coordinator.add_to_queue(test_contributor_2.participant.clone(), Some(contributor_2_ip), token2, 9)?;
+    coordinator.add_to_queue(
+        test_contributor_1.participant.clone(),
+        Some(contributor_1_ip),
+        token,
+        10,
+    )?;
+    coordinator.add_to_queue(
+        test_contributor_2.participant.clone(),
+        Some(contributor_2_ip),
+        token2,
+        9,
+    )?;
 
     // Update the ceremony to round 1.
     coordinator.update()?;
@@ -1926,8 +1966,18 @@ fn drop_all_contributors_and_complete_round() -> anyhow::Result<()> {
     let contributor_3_ip = IpAddr::V4("0.0.0.3".parse().unwrap());
     let test_contributor_4 = create_contributor_test_details("4");
     let contributor_4_ip = IpAddr::V4("0.0.0.4".parse().unwrap());
-    coordinator.add_to_queue(test_contributor_3.participant.clone(), Some(contributor_3_ip), token3, 10)?;
-    coordinator.add_to_queue(test_contributor_4.participant.clone(), Some(contributor_4_ip), token4, 10)?;
+    coordinator.add_to_queue(
+        test_contributor_3.participant.clone(),
+        Some(contributor_3_ip),
+        token3,
+        10,
+    )?;
+    coordinator.add_to_queue(
+        test_contributor_4.participant.clone(),
+        Some(contributor_4_ip),
+        token4,
+        10,
+    )?;
 
     // Update the ceremony to round 2.
     coordinator.update()?;

--- a/phase1-coordinator/src/tests.rs
+++ b/phase1-coordinator/src/tests.rs
@@ -324,7 +324,6 @@ fn coordinator_drop_contributor_basic() {
     );
 }
 
-// FIXME: load some tokens in these tests?
 #[test]
 #[serial]
 /// Drops a contributor in between two contributors.

--- a/phase1-coordinator/src/tests.rs
+++ b/phase1-coordinator/src/tests.rs
@@ -112,8 +112,9 @@ fn execute_round(proving_system: ProvingSystem, curve: CurveKind) -> anyhow::Res
     // Meanwhile, add a contributor and verifier to the queue.
     let (contributor, contributor_signing_key, seed) = create_contributor("1");
     let contributor_ip = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
+    let token = String::from("test_token");
     let (verifier, verifier_signing_key) = create_verifier("1");
-    coordinator.add_to_queue(contributor.clone(), Some(contributor_ip), 10)?;
+    coordinator.add_to_queue(contributor.clone(), Some(contributor_ip), token.clone(), 10)?;
     assert_eq!(1, coordinator.number_of_queue_contributors());
 
     // Advance the ceremony from round 0 to round 1.
@@ -137,7 +138,7 @@ fn execute_round(proving_system: ProvingSystem, curve: CurveKind) -> anyhow::Res
     // changing the outcome of this test, if necessary.
     //
     let (contributor, _, _) = create_contributor("1");
-    coordinator.add_to_queue(contributor.clone(), Some(contributor_ip), 10)?;
+    coordinator.add_to_queue(contributor.clone(), Some(contributor_ip), token, 10)?;
     assert_eq!(1, coordinator.number_of_queue_contributors());
 
     // Update the ceremony from round 1 to round 2.
@@ -230,16 +231,18 @@ fn coordinator_drop_contributor_basic() {
     assert_eq!(0, coordinator.current_round_height().unwrap());
 
     // Add a contributor and verifier to the queue.
+    let token1 = String::from("test_token");
+    let token2 = String::from("test_token_2");
     let (contributor1, contributor_signing_key1, seed1) = create_contributor("1");
     let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
     let (contributor2, contributor_signing_key2, seed2) = create_contributor("2");
     let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let (verifier, verifier_signing_key) = create_verifier("1");
     coordinator
-        .add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)
+        .add_to_queue(contributor1.clone(), Some(contributor_1_ip), token1, 10)
         .unwrap();
     coordinator
-        .add_to_queue(contributor2.clone(), Some(contributor_2_ip), 9)
+        .add_to_queue(contributor2.clone(), Some(contributor_2_ip), token2, 9)
         .unwrap();
     assert_eq!(2, coordinator.number_of_queue_contributors());
     assert!(coordinator.is_queue_contributor(&contributor1));
@@ -321,6 +324,7 @@ fn coordinator_drop_contributor_basic() {
     );
 }
 
+// FIXME: load some tokens in these tests?
 #[test]
 #[serial]
 /// Drops a contributor in between two contributors.
@@ -344,6 +348,9 @@ fn coordinator_drop_contributor_in_between_two_contributors() -> anyhow::Result<
     assert_eq!(0, coordinator.current_round_height()?);
 
     // Add a contributor and verifier to the queue.
+    let token = String::from("test_token");
+    let token2 = String::from("test_token_2");
+    let token3 = String::from("test_token_3");
     let (contributor1, contributor_signing_key1, seed1) = create_contributor("1");
     let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
     let (contributor2, contributor_signing_key2, seed2) = create_contributor("2");
@@ -351,9 +358,9 @@ fn coordinator_drop_contributor_in_between_two_contributors() -> anyhow::Result<
     let (contributor3, contributor_signing_key3, seed3) = create_contributor("3");
     let contributor_3_ip = IpAddr::V4("0.0.0.3".parse().unwrap());
     let (verifier, verifier_signing_key) = create_verifier("1");
-    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)?;
-    coordinator.add_to_queue(contributor2.clone(), Some(contributor_2_ip), 9)?;
-    coordinator.add_to_queue(contributor3.clone(), Some(contributor_3_ip), 8)?;
+    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), token, 10)?;
+    coordinator.add_to_queue(contributor2.clone(), Some(contributor_2_ip), token2, 9)?;
+    coordinator.add_to_queue(contributor3.clone(), Some(contributor_3_ip), token3, 8)?;
     assert_eq!(3, coordinator.number_of_queue_contributors());
 
     // Update the ceremony to round 1.
@@ -467,6 +474,9 @@ fn coordinator_drop_contributor_with_contributors_in_pending_tasks() -> anyhow::
     assert_eq!(0, coordinator.current_round_height()?);
 
     // Add a contributor and verifier to the queue.
+    let token = String::from("test_token");
+    let token2 = String::from("test_token_2");
+    let token3 = String::from("test_token_3");
     let (contributor1, contributor_signing_key1, seed1) = create_contributor("1");
     let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
     let (contributor2, contributor_signing_key2, seed2) = create_contributor("2");
@@ -474,9 +484,9 @@ fn coordinator_drop_contributor_with_contributors_in_pending_tasks() -> anyhow::
     let (contributor3, contributor_signing_key3, seed3) = create_contributor("3");
     let contributor_3_ip = IpAddr::V4("0.0.0.3".parse().unwrap());
     let (verifier, verifier_signing_key) = create_verifier("1");
-    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)?;
-    coordinator.add_to_queue(contributor2.clone(), Some(contributor_2_ip), 9)?;
-    coordinator.add_to_queue(contributor3.clone(), Some(contributor_3_ip), 8)?;
+    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), token, 10)?;
+    coordinator.add_to_queue(contributor2.clone(), Some(contributor_2_ip), token2, 9)?;
+    coordinator.add_to_queue(contributor3.clone(), Some(contributor_3_ip), token3, 8)?;
     assert_eq!(3, coordinator.number_of_queue_contributors());
 
     // Update the ceremony to round 1.
@@ -623,6 +633,9 @@ fn coordinator_drop_contributor_locked_chunks() -> anyhow::Result<()> {
     assert_eq!(0, coordinator.current_round_height()?);
 
     // Add a contributor and verifier to the queue.
+    let token = String::from("test_token");
+    let token2 = String::from("test_token_2");
+    let token3 = String::from("test_token_3");
     let (contributor1, contributor_signing_key1, seed1) = create_contributor("1");
     let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
     let (contributor2, contributor_signing_key2, seed2) = create_contributor("2");
@@ -630,9 +643,9 @@ fn coordinator_drop_contributor_locked_chunks() -> anyhow::Result<()> {
     let (contributor3, contributor_signing_key3, seed3) = create_contributor("3");
     let contributor_3_ip = IpAddr::V4("0.0.0.3".parse().unwrap());
     let (verifier, verifier_signing_key) = create_verifier("1");
-    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)?;
-    coordinator.add_to_queue(contributor2.clone(), Some(contributor_2_ip), 9)?;
-    coordinator.add_to_queue(contributor3.clone(), Some(contributor_3_ip), 8)?;
+    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), token, 10)?;
+    coordinator.add_to_queue(contributor2.clone(), Some(contributor_2_ip), token2, 9)?;
+    coordinator.add_to_queue(contributor3.clone(), Some(contributor_3_ip), token3, 8)?;
     assert_eq!(3, coordinator.number_of_queue_contributors());
 
     // Update the ceremony to round 1.
@@ -785,13 +798,15 @@ fn coordinator_drop_contributor_removes_contributions() -> anyhow::Result<()> {
     assert_eq!(0, coordinator.current_round_height()?);
 
     // Add a contributor and verifier to the queue.
+    let token = String::from("test_token");
+    let token2 = String::from("test_token_2");
     let (contributor1, contributor_signing_key1, seed1) = create_contributor("1");
     let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
     let (contributor2, contributor_signing_key2, seed2) = create_contributor("2");
     let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let (verifier, verifier_signing_key) = create_verifier("1");
-    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)?;
-    coordinator.add_to_queue(contributor2.clone(), Some(contributor_2_ip), 9)?;
+    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), token, 10)?;
+    coordinator.add_to_queue(contributor2.clone(), Some(contributor_2_ip), token2, 9)?;
     assert_eq!(2, coordinator.number_of_queue_contributors());
     assert!(coordinator.is_queue_contributor(&contributor1));
     assert!(coordinator.is_queue_contributor(&contributor2));
@@ -900,6 +915,9 @@ fn coordinator_drop_contributor_clear_locks() -> anyhow::Result<()> {
     assert_eq!(0, coordinator.current_round_height().unwrap());
 
     // Add a contributor and verifier to the queue.
+    let token = String::from("test_token");
+    let token2 = String::from("test_token_2");
+    let token3 = String::from("test_token_3");
     let (contributor1, contributor_signing_key1, seed1) = create_contributor("1");
     let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
     let (contributor2, contributor_signing_key2, seed2) = create_contributor("2");
@@ -908,13 +926,13 @@ fn coordinator_drop_contributor_clear_locks() -> anyhow::Result<()> {
     let contributor_3_ip = IpAddr::V4("0.0.0.3".parse().unwrap());
     let (verifier, verifier_signing_key) = create_verifier("1");
     coordinator
-        .add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)
+        .add_to_queue(contributor1.clone(), Some(contributor_1_ip), token, 10)
         .unwrap();
     coordinator
-        .add_to_queue(contributor2.clone(), Some(contributor_2_ip), 9)
+        .add_to_queue(contributor2.clone(), Some(contributor_2_ip), token2, 9)
         .unwrap();
     coordinator
-        .add_to_queue(contributor3.clone(), Some(contributor_3_ip), 8)
+        .add_to_queue(contributor3.clone(), Some(contributor_3_ip), token3, 8)
         .unwrap();
     assert_eq!(3, coordinator.number_of_queue_contributors());
 
@@ -1106,13 +1124,15 @@ fn coordinator_drop_contributor_removes_subsequent_contributions() -> anyhow::Re
     assert_eq!(0, coordinator.current_round_height()?);
 
     // Add a contributor and verifier to the queue.
+    let token = String::from("test_token");
+    let token2 = String::from("test_token_2");
     let (contributor1, contributor_signing_key1, seed1) = create_contributor("1");
     let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
     let (contributor2, contributor_signing_key2, seed2) = create_contributor("2");
     let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let (verifier, verifier_signing_key) = create_verifier("1");
-    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)?;
-    coordinator.add_to_queue(contributor2.clone(), Some(contributor_2_ip), 9)?;
+    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), token, 10)?;
+    coordinator.add_to_queue(contributor2.clone(), Some(contributor_2_ip), token2, 9)?;
 
     // Update the ceremony to round 1.
     coordinator.update()?;
@@ -1191,16 +1211,18 @@ fn coordinator_drop_contributor_and_release_locks() {
     assert_eq!(0, coordinator.current_round_height().unwrap());
 
     // Add a contributor and verifier to the queue.
+    let token = String::from("test_token");
+    let token2 = String::from("test_token_2");
     let contributor_1 = create_contributor_test_details("1");
     let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
     let contributor_2 = create_contributor_test_details("2");
     let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let verifier_1 = create_verifier_test_details("1");
     coordinator
-        .add_to_queue(contributor_1.participant.clone(), Some(contributor_1_ip), 10)
+        .add_to_queue(contributor_1.participant.clone(), Some(contributor_1_ip), token, 10)
         .unwrap();
     coordinator
-        .add_to_queue(contributor_2.participant.clone(), Some(contributor_2_ip), 9)
+        .add_to_queue(contributor_2.participant.clone(), Some(contributor_2_ip), token2, 9)
         .unwrap();
 
     // Update the ceremony to round 1.
@@ -1221,15 +1243,17 @@ fn coordinator_drop_contributor_and_release_locks() {
     }
 
     // Add some more participants to proceed to the next round
+    let token3 = String::from("test_token_3");
+    let token4 = String::from("test_token_4");
     let test_contributor_3 = create_contributor_test_details("3");
     let contributor_3_ip = IpAddr::V4("0.0.0.3".parse().unwrap());
     let test_contributor_4 = create_contributor_test_details("4");
     let contributor_4_ip = IpAddr::V4("0.0.0.4".parse().unwrap());
     coordinator
-        .add_to_queue(test_contributor_3.participant.clone(), Some(contributor_3_ip), 10)
+        .add_to_queue(test_contributor_3.participant.clone(), Some(contributor_3_ip), token3, 10)
         .unwrap();
     coordinator
-        .add_to_queue(test_contributor_4.participant.clone(), Some(contributor_4_ip), 10)
+        .add_to_queue(test_contributor_4.participant.clone(), Some(contributor_4_ip), token4, 10)
         .unwrap();
 
     // Update the ceremony to round 2.
@@ -1270,6 +1294,9 @@ fn coordinator_drop_several_contributors() {
     assert_eq!(0, coordinator.current_round_height().unwrap());
 
     // Add some contributors and one verifier to the queue.
+    let token = String::from("test_token");
+    let token2 = String::from("test_token_2");
+    let token3 = String::from("test_token_3");
     let contributor_1 = create_contributor_test_details("1");
     let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
     let contributor_2 = create_contributor_test_details("2");
@@ -1278,13 +1305,13 @@ fn coordinator_drop_several_contributors() {
     let contributor_3_ip = IpAddr::V4("0.0.0.3".parse().unwrap());
     let verifier_1 = create_verifier_test_details("1");
     coordinator
-        .add_to_queue(contributor_1.participant.clone(), Some(contributor_1_ip), 10)
+        .add_to_queue(contributor_1.participant.clone(), Some(contributor_1_ip), token, 10)
         .unwrap();
     coordinator
-        .add_to_queue(contributor_2.participant.clone(), Some(contributor_2_ip), 10)
+        .add_to_queue(contributor_2.participant.clone(), Some(contributor_2_ip), token2, 10)
         .unwrap();
     coordinator
-        .add_to_queue(contributor_3.participant.clone(), Some(contributor_3_ip), 10)
+        .add_to_queue(contributor_3.participant.clone(), Some(contributor_3_ip), token3, 10)
         .unwrap();
 
     // Update the ceremony to round 1.
@@ -1355,15 +1382,17 @@ fn coordinator_drop_several_contributors() {
     }
 
     // Add some more participants to proceed to the next round
+    let token3 = String::from("test_token_3");
+    let token4 = String::from("test_token_4");
     let test_contributor_3 = create_contributor_test_details("3");
     let contributor_3_ip = IpAddr::V4("0.0.0.3".parse().unwrap());
     let test_contributor_4 = create_contributor_test_details("4");
     let contributor_4_ip = IpAddr::V4("0.0.0.4".parse().unwrap());
     coordinator
-        .add_to_queue(test_contributor_3.participant.clone(), Some(contributor_3_ip), 10)
+        .add_to_queue(test_contributor_3.participant.clone(), Some(contributor_3_ip), token3, 10)
         .unwrap();
     coordinator
-        .add_to_queue(test_contributor_4.participant.clone(), Some(contributor_4_ip), 10)
+        .add_to_queue(test_contributor_4.participant.clone(), Some(contributor_4_ip), token4, 10)
         .unwrap();
 
     // Update the ceremony to round 2.
@@ -1486,16 +1515,18 @@ fn coordinator_drop_contributor_and_update_verifier_tasks() {
     assert_eq!(0, coordinator.current_round_height().unwrap());
 
     // Add a contributor and verifier to the queue.
+    let token = String::from("test_token");
+    let token2 = String::from("test_token_2");
     let contributor_1 = create_contributor_test_details("1");
     let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
     let contributor_2 = create_contributor_test_details("2");
     let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let verifier_1 = create_verifier_test_details("1");
     coordinator
-        .add_to_queue(contributor_1.participant.clone(), Some(contributor_1_ip), 10)
+        .add_to_queue(contributor_1.participant.clone(), Some(contributor_1_ip), token, 10)
         .unwrap();
     coordinator
-        .add_to_queue(contributor_2.participant.clone(), Some(contributor_2_ip), 9)
+        .add_to_queue(contributor_2.participant.clone(), Some(contributor_2_ip), token2, 9)
         .unwrap();
 
     // Update the ceremony to round 1.
@@ -1516,15 +1547,17 @@ fn coordinator_drop_contributor_and_update_verifier_tasks() {
     }
 
     // Add some more participants to proceed to the next round
+    let token3 = String::from("test_token_3");
+    let token4 = String::from("test_token_4");
     let test_contributor_3 = create_contributor_test_details("3");
     let contributor_3_ip = IpAddr::V4("0.0.0.3".parse().unwrap());
     let test_contributor_4 = create_contributor_test_details("4");
     let contributor_4_ip = IpAddr::V4("0.0.0.4".parse().unwrap());
     coordinator
-        .add_to_queue(test_contributor_3.participant.clone(), Some(contributor_3_ip), 10)
+        .add_to_queue(test_contributor_3.participant.clone(), Some(contributor_3_ip), token3, 10)
         .unwrap();
     coordinator
-        .add_to_queue(test_contributor_4.participant.clone(), Some(contributor_4_ip), 10)
+        .add_to_queue(test_contributor_4.participant.clone(), Some(contributor_4_ip), token4, 10)
         .unwrap();
 
     // Update the ceremony to round 2.
@@ -1562,6 +1595,9 @@ fn coordinator_drop_multiple_contributors() -> anyhow::Result<()> {
     assert_eq!(0, coordinator.current_round_height()?);
 
     // Add a contributor and verifier to the queue.
+    let token = String::from("test_token");
+    let token2 = String::from("test_token_2");
+    let token3 = String::from("test_token_3");
     let (contributor1, contributor_signing_key1, seed1) = create_contributor("1");
     let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
     let (contributor2, contributor_signing_key2, seed2) = create_contributor("2");
@@ -1569,9 +1605,9 @@ fn coordinator_drop_multiple_contributors() -> anyhow::Result<()> {
     let (contributor3, contributor_signing_key3, seed3) = create_contributor("3");
     let contributor_3_ip = IpAddr::V4("0.0.0.3".parse().unwrap());
     let (verifier, verifier_signing_key) = create_verifier("1");
-    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)?;
-    coordinator.add_to_queue(contributor2.clone(), Some(contributor_2_ip), 9)?;
-    coordinator.add_to_queue(contributor3.clone(), Some(contributor_3_ip), 8)?;
+    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), token, 10)?;
+    coordinator.add_to_queue(contributor2.clone(), Some(contributor_2_ip), token2, 9)?;
+    coordinator.add_to_queue(contributor3.clone(), Some(contributor_3_ip), token3, 8)?;
     assert_eq!(3, coordinator.number_of_queue_contributors());
 
     // Update the ceremony to round 1.
@@ -1712,13 +1748,15 @@ fn try_lock_blocked() -> anyhow::Result<()> {
     assert_eq!(0, coordinator.current_round_height()?);
 
     // Meanwhile, add 2 contributors and 1 verifier to the queue.
+    let token = String::from("test_token");
+    let token2 = String::from("test_token_2");
     let (contributor1, contributor_signing_key1, seed1) = create_contributor("1");
     let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
     let (contributor2, contributor_signing_key2, seed2) = create_contributor("2");
     let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let (verifier, verifier_signing_key) = create_verifier("1");
-    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)?;
-    coordinator.add_to_queue(contributor2.clone(), Some(contributor_2_ip), 10)?;
+    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), token, 10)?;
+    coordinator.add_to_queue(contributor2.clone(), Some(contributor_2_ip), token2, 10)?;
     assert_eq!(2, coordinator.number_of_queue_contributors());
 
     // Advance the ceremony from round 0 to round 1.
@@ -1838,13 +1876,15 @@ fn drop_all_contributors_and_complete_round() -> anyhow::Result<()> {
     assert_eq!(0, coordinator.current_round_height()?);
 
     // Add a contributor and verifier to the queue.
+    let token = String::from("test_token");
+    let token2 = String::from("test_token_2");
     let test_contributor_1 = create_contributor_test_details("1");
     let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
     let test_contributor_2 = create_contributor_test_details("2");
     let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let (verifier, verifier_signing_key) = create_verifier("1");
-    coordinator.add_to_queue(test_contributor_1.participant.clone(), Some(contributor_1_ip), 10)?;
-    coordinator.add_to_queue(test_contributor_2.participant.clone(), Some(contributor_2_ip), 9)?;
+    coordinator.add_to_queue(test_contributor_1.participant.clone(), Some(contributor_1_ip), token, 10)?;
+    coordinator.add_to_queue(test_contributor_2.participant.clone(), Some(contributor_2_ip), token2, 9)?;
 
     // Update the ceremony to round 1.
     coordinator.update()?;
@@ -1881,12 +1921,14 @@ fn drop_all_contributors_and_complete_round() -> anyhow::Result<()> {
     }
 
     // Add some more participants to proceed to the next round
+    let token3 = String::from("test_token_3");
+    let token4 = String::from("test_token_4");
     let test_contributor_3 = create_contributor_test_details("3");
     let contributor_3_ip = IpAddr::V4("0.0.0.3".parse().unwrap());
     let test_contributor_4 = create_contributor_test_details("4");
     let contributor_4_ip = IpAddr::V4("0.0.0.4".parse().unwrap());
-    coordinator.add_to_queue(test_contributor_3.participant.clone(), Some(contributor_3_ip), 10)?;
-    coordinator.add_to_queue(test_contributor_4.participant.clone(), Some(contributor_4_ip), 10)?;
+    coordinator.add_to_queue(test_contributor_3.participant.clone(), Some(contributor_3_ip), token3, 10)?;
+    coordinator.add_to_queue(test_contributor_4.participant.clone(), Some(contributor_4_ip), token4, 10)?;
 
     // Update the ceremony to round 2.
     coordinator.update()?;
@@ -1918,13 +1960,15 @@ fn drop_contributor_and_reassign_tasks() -> anyhow::Result<()> {
     assert_eq!(0, coordinator.current_round_height()?);
 
     // Add a contributor and verifier to the queue.
+    let token = String::from("test_token");
+    let token2 = String::from("test_token_2");
     let (contributor1, contributor_signing_key1, seed1) = create_contributor("1");
     let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
     let (contributor2, contributor_signing_key2, seed2) = create_contributor("2");
     let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let (verifier, verifier_signing_key) = create_verifier("1");
-    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)?;
-    coordinator.add_to_queue(contributor2.clone(), Some(contributor_2_ip), 9)?;
+    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), token, 10)?;
+    coordinator.add_to_queue(contributor2.clone(), Some(contributor_2_ip), token2, 9)?;
 
     // Update the ceremony to round 1.
     coordinator.update()?;
@@ -1999,9 +2043,10 @@ fn contributor_timeout_drop_test() -> anyhow::Result<()> {
     coordinator.initialize()?;
 
     let (contributor1, _contributor_signing_key1, _seed1) = create_contributor("1");
+    let token = String::from("test_token");
     let contributor_1_ip = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
 
-    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)?;
+    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), token, 10)?;
 
     // Update the ceremony to round 1.
     coordinator.update()?;
@@ -2059,13 +2104,15 @@ fn contributor_wait_verifier_test() -> anyhow::Result<()> {
     // Initialize the ceremony to round 0.
     coordinator.initialize()?;
 
+    let token = String::from("test_token");
+    let token2 = String::from("test_token_2");
     let (contributor1, contributor_signing_key1, seed1) = create_contributor("1");
     let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
     let (contributor2, contributor_signing_key2, seed2) = create_contributor("2");
     let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
 
-    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)?;
-    coordinator.add_to_queue(contributor2.clone(), Some(contributor_2_ip), 10)?;
+    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), token, 10)?;
+    coordinator.add_to_queue(contributor2.clone(), Some(contributor_2_ip), token2, 10)?;
 
     // Update the ceremony to round 1.
     coordinator.update()?;
@@ -2136,8 +2183,9 @@ fn participant_lock_timeout_drop_test() -> anyhow::Result<()> {
 
     let (contributor1, contributor_signing_key1, seed1) = create_contributor("1");
     let contributor_1_ip = IpAddr::V4(Ipv4Addr::UNSPECIFIED);
+    let token = String::from("test_token");
 
-    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)?;
+    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), token, 10)?;
 
     // Update the ceremony to round 1.
     coordinator.update()?;
@@ -2202,8 +2250,10 @@ fn queue_seen_timeout_drop_test() -> anyhow::Result<()> {
 
     let (contributor1, _, _) = create_contributor("1");
     let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
+    let token = String::from("test_token");
+    let token2 = String::from("test_token_2");
 
-    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)?;
+    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), token, 10)?;
 
     // Update the ceremony to round 1.
     coordinator.update()?;
@@ -2211,7 +2261,7 @@ fn queue_seen_timeout_drop_test() -> anyhow::Result<()> {
     // Add another contributor who we are gonna try to drop
     let (contributor2, _, _) = create_contributor("2");
     let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
-    coordinator.add_to_queue(contributor2.clone(), Some(contributor_2_ip), 10)?;
+    coordinator.add_to_queue(contributor2.clone(), Some(contributor_2_ip), token2, 10)?;
 
     assert_eq!(1, coordinator.current_contributors().len());
     assert!(coordinator.is_queue_contributor(&contributor2));
@@ -2268,8 +2318,10 @@ fn queue_seen_timeout_heartbeat_test() -> anyhow::Result<()> {
 
     let (contributor1, _, _) = create_contributor("1");
     let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
+    let token = String::from("test_token");
+    let token2 = String::from("test_token_2");
 
-    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)?;
+    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), token, 10)?;
 
     // Update the ceremony to round 1.
     coordinator.update()?;
@@ -2278,7 +2330,7 @@ fn queue_seen_timeout_heartbeat_test() -> anyhow::Result<()> {
     let (contributor2, _, _) = create_contributor("2");
     let contributor_2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
 
-    coordinator.add_to_queue(contributor2.clone(), Some(contributor_2_ip), 10)?;
+    coordinator.add_to_queue(contributor2.clone(), Some(contributor_2_ip), token2, 10)?;
 
     assert_eq!(1, coordinator.current_contributors().len());
     assert!(coordinator.is_queue_contributor(&contributor2));
@@ -2340,8 +2392,9 @@ fn rollback_locked_chunk() -> anyhow::Result<()> {
 
     let (contributor1, contributor_signing_key1, seed1) = create_contributor("1");
     let contributor_1_ip = IpAddr::V4("0.0.0.1".parse().unwrap());
+    let token = String::from("test_token");
 
-    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), 10)?;
+    coordinator.add_to_queue(contributor1.clone(), Some(contributor_1_ip), token, 10)?;
 
     // Update the ceremony to round 1.
     coordinator.update()?;

--- a/phase1-coordinator/tests/test_coordinator.rs
+++ b/phase1-coordinator/tests/test_coordinator.rs
@@ -110,7 +110,9 @@ fn build_context() -> TestCtx {
     let contributor2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let unknown_contributor_ip = IpAddr::V4("0.0.0.3".parse().unwrap());
 
-    let token = String::from("9nFeNpukSn1eVwNc2vkfP7rdLh2njm5ewmCGxSLTW3GYmKP51fKjbRUvHDmntjEaQiq7iFux9tumgWEWVHwHQCs31oitpqBpMWpMydo1DnuFyLpsD6C");
+    let token = String::from(
+        "9nFeNpukSn1eVwNc2vkfP7rdLh2njm5ewmCGxSLTW3GYmKP51fKjbRUvHDmntjEaQiq7iFux9tumgWEWVHwHQCs31oitpqBpMWpMydo1DnuFyLpsD6C",
+    );
 
     coordinator.initialize().unwrap();
     let coordinator_keypair = KeyPair::custom_new(
@@ -276,7 +278,9 @@ fn test_update_cohorts() {
     std::fs::remove_file(TOKENS_ZIP_FILE).ok();
 
     // Create new tokens zip file
-    let new_invalid_tokens = get_serialized_tokens_zip(vec!["[\"9nFeNpukSn1eVwNc2vkfP7rdLh2njm5ewmCGxSLTW3GYmKP51fKjbRUvHDmntjEaQiq7iFux9tumgWEWVHwHQCs31oitpqBpMWpMydo1DnuFyLpsD6C\", \"9nFeNpukSn1eVwNc2vkfP7sQsLG3oS7623phb2Zzc23GAdXjuby4XAbwbWbx1uNaYrZorVLio4ZSt3u95sgi4fsS8hiZ3XkEttBF6q4461dGpoWv7ek\"]"]);
+    let new_invalid_tokens = get_serialized_tokens_zip(vec![
+        "[\"9nFeNpukSn1eVwNc2vkfP7rdLh2njm5ewmCGxSLTW3GYmKP51fKjbRUvHDmntjEaQiq7iFux9tumgWEWVHwHQCs31oitpqBpMWpMydo1DnuFyLpsD6C\", \"9nFeNpukSn1eVwNc2vkfP7sQsLG3oS7623phb2Zzc23GAdXjuby4XAbwbWbx1uNaYrZorVLio4ZSt3u95sgi4fsS8hiZ3XkEttBF6q4461dGpoWv7ek\"]",
+    ]);
 
     // Wrong, request from non-coordinator participant
     let mut req = client.post("/update_cohorts");
@@ -431,7 +435,9 @@ fn test_join_queue() {
     req = set_request::<String>(
         req,
         &ctx.unknown_participant.keypair,
-        Some(&format!("9nFeNpukSn1eVwNc2vkfP8SP4HrxTh9F86CY5pNWw8RF3jZa91q2i3yvE7ugpn9w2RzoZBZrdskgckmvJuVKq6ZWxfV8TepZYFd9SeARGHexi7tGGV3")),
+        Some(&format!(
+            "9nFeNpukSn1eVwNc2vkfP8SP4HrxTh9F86CY5pNWw8RF3jZa91q2i3yvE7ugpn9w2RzoZBZrdskgckmvJuVKq6ZWxfV8TepZYFd9SeARGHexi7tGGV3"
+        )),
     );
     let response = req.dispatch();
     assert_eq!(response.status(), Status::Unauthorized);
@@ -449,7 +455,9 @@ fn test_join_queue() {
     req = set_request::<String>(
         req,
         &ctx.unknown_participant.keypair,
-        Some(&format!("9nFeNpukSn1eVwNc2vkfP7sQsLG3oS7623phb2Zzc23GAdXjuby4XAbwbWbx1uNaYrZorVLio4ZSt3u95sgi4fsS8hiZ3XkEttBF6q4461dGpoWv7ek")),
+        Some(&format!(
+            "9nFeNpukSn1eVwNc2vkfP7sQsLG3oS7623phb2Zzc23GAdXjuby4XAbwbWbx1uNaYrZorVLio4ZSt3u95sgi4fsS8hiZ3XkEttBF6q4461dGpoWv7ek"
+        )),
     );
     let response = req.dispatch();
     assert_eq!(response.status(), Status::Ok);
@@ -460,7 +468,9 @@ fn test_join_queue() {
     req = set_request::<String>(
         req,
         &ctx.contributors[1].keypair,
-        Some(&format!("9nFeNpukSn1eVwNc2vkfP8SP4HrxTh9F86CY5pNWw8RF3jZa91q2i3yvE7ugpn9w2RzoZBZrdskgckmvJuVKq6ZWxfV8TepZYFd9SeARGHexi7tGGV2")),
+        Some(&format!(
+            "9nFeNpukSn1eVwNc2vkfP8SP4HrxTh9F86CY5pNWw8RF3jZa91q2i3yvE7ugpn9w2RzoZBZrdskgckmvJuVKq6ZWxfV8TepZYFd9SeARGHexi7tGGV2"
+        )),
     );
     let response = req.dispatch();
     assert_eq!(response.status(), Status::Unauthorized);
@@ -472,7 +482,9 @@ fn test_join_queue() {
     req = set_request::<String>(
         req,
         &ctx.contributors[1].keypair,
-        Some(&format!("9nFeNpukSn1eVwNc2vkfP7sQsLG3oS7623phb2Zzc23GAdXjuby4XAbwbWbx1uNaYrZorVLio4ZSt3u95sgi4fsS8hiZ3XkEttBF6q4461dGpoWv7ek")),
+        Some(&format!(
+            "9nFeNpukSn1eVwNc2vkfP7sQsLG3oS7623phb2Zzc23GAdXjuby4XAbwbWbx1uNaYrZorVLio4ZSt3u95sgi4fsS8hiZ3XkEttBF6q4461dGpoWv7ek"
+        )),
     );
     let response = req.dispatch();
     assert_eq!(response.status(), Status::Unauthorized);
@@ -483,7 +495,9 @@ fn test_join_queue() {
     req = set_request::<String>(
         req,
         &ctx.unknown_participant.keypair,
-        Some(&format!("9nFeNpukSn1eVwNc2vkfP8SP4HrxTh9F86CY5pNWw8RF3jZa91q2i3yvE7ugpn9w2RzoZBZrdskgckmvJuVKq6ZWxfV8TepZYFd9SeARGHexi7tGGV2")),
+        Some(&format!(
+            "9nFeNpukSn1eVwNc2vkfP8SP4HrxTh9F86CY5pNWw8RF3jZa91q2i3yvE7ugpn9w2RzoZBZrdskgckmvJuVKq6ZWxfV8TepZYFd9SeARGHexi7tGGV2"
+        )),
     );
     let response = req.dispatch();
     assert_eq!(response.status(), Status::Unauthorized);
@@ -811,7 +825,9 @@ fn test_contribution() {
     req = set_request::<String>(
         req,
         &ctx.unknown_participant.keypair,
-        Some(&format!("9nFeNpukSn1eVwNc2vkfP8SP4HrxTh9F86CY5pNWw8RF3jZa91q2i3yvE7ugpn9w2RzoZBZrdskgckmvJuVKq6ZWxfV8TepZYFd9SeARGHexi7tGGV2")),
+        Some(&format!(
+            "9nFeNpukSn1eVwNc2vkfP8SP4HrxTh9F86CY5pNWw8RF3jZa91q2i3yvE7ugpn9w2RzoZBZrdskgckmvJuVKq6ZWxfV8TepZYFd9SeARGHexi7tGGV2"
+        )),
     );
     let response = req.dispatch();
     assert_eq!(response.status(), Status::Unauthorized);
@@ -824,7 +840,9 @@ fn test_contribution() {
     req = set_request::<String>(
         req,
         &ctx.unknown_participant.keypair,
-        Some(&format!("9nFeNpukSn1eVwNc2vkfP7rdLh2njm5ewmCGxSLTW3GYmKP51fKjbRUvHDmntjEaQiq7iFux9tumgWEWVHwHQCs31oitpqBpMWpMydo1DnuFyLpsD6C")),
+        Some(&format!(
+            "9nFeNpukSn1eVwNc2vkfP7rdLh2njm5ewmCGxSLTW3GYmKP51fKjbRUvHDmntjEaQiq7iFux9tumgWEWVHwHQCs31oitpqBpMWpMydo1DnuFyLpsD6C"
+        )),
     );
     let response = req.dispatch();
     assert_eq!(response.status(), Status::Unauthorized);
@@ -838,7 +856,9 @@ fn test_contribution() {
     req = set_request::<String>(
         req,
         &ctx.unknown_participant.keypair,
-        Some(&format!("9nFeNpukSn1eVwNc2vkfP7sQsLG3oS7623phb2Zzc23GAdXjuby4XAbwbWbx1uNaYrZorVLio4ZSt3u95sgi4fsS8hiZ3XkEttBF6q4461dGpoWv7ek")),
+        Some(&format!(
+            "9nFeNpukSn1eVwNc2vkfP7sQsLG3oS7623phb2Zzc23GAdXjuby4XAbwbWbx1uNaYrZorVLio4ZSt3u95sgi4fsS8hiZ3XkEttBF6q4461dGpoWv7ek"
+        )),
     );
     let response = req.dispatch();
     assert_eq!(response.status(), Status::Unauthorized);
@@ -849,7 +869,9 @@ fn test_contribution() {
     req = set_request::<String>(
         req,
         &ctx.unknown_participant.keypair,
-        Some(&format!("9nFeNpukSn1eVwNc2vkfP8TAaw6DXNAgCNpxiQc437BxT3iF2xUMdo6wYQjqwxHwAZjVhQzdH3QMpJSbXvaDcnkVu6Ktt22AfYDypK2h72vuQK9fGNp")),
+        Some(&format!(
+            "9nFeNpukSn1eVwNc2vkfP8TAaw6DXNAgCNpxiQc437BxT3iF2xUMdo6wYQjqwxHwAZjVhQzdH3QMpJSbXvaDcnkVu6Ktt22AfYDypK2h72vuQK9fGNp"
+        )),
     );
     let response = req.dispatch();
     assert_eq!(response.status(), Status::Ok);

--- a/phase1-coordinator/tests/test_coordinator.rs
+++ b/phase1-coordinator/tests/test_coordinator.rs
@@ -97,6 +97,8 @@ fn build_context() -> TestCtx {
     let contributor2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let unknown_contributor_ip = IpAddr::V4("0.0.0.3".parse().unwrap());
 
+    let token = String::from("test-token");
+
     coordinator.initialize().unwrap();
     let coordinator_keypair = KeyPair::custom_new(
         coordinator.environment().default_verifier_signing_key(),
@@ -111,7 +113,7 @@ fn build_context() -> TestCtx {
     };
 
     coordinator
-        .add_to_queue(contributor1.clone(), Some(contributor1_ip.clone()), 10)
+        .add_to_queue(contributor1.clone(), Some(contributor1_ip.clone()), token, 10)
         .unwrap();
     coordinator.update().unwrap();
 

--- a/phase1-coordinator/tests/test_coordinator.rs
+++ b/phase1-coordinator/tests/test_coordinator.rs
@@ -65,7 +65,7 @@ struct TestCtx {
     unknown_participant: TestParticipant,
     coordinator: TestParticipant,
     // Keep TempDir in scope for some tests
-    _tokens_tmp_dir: tempfile::TempDir
+    _tokens_tmp_dir: tempfile::TempDir,
 }
 
 /// Build the rocket server for testing with the proper configuration.
@@ -188,7 +188,7 @@ fn build_context() -> TestCtx {
         contributors: vec![test_participant1, test_participant2],
         unknown_participant,
         coordinator: coord_verifier,
-        _tokens_tmp_dir: tmp_dir
+        _tokens_tmp_dir: tmp_dir,
     }
 }
 

--- a/phase1-coordinator/tests/test_coordinator.rs
+++ b/phase1-coordinator/tests/test_coordinator.rs
@@ -90,7 +90,7 @@ fn build_context() -> TestCtx {
     let file_path = tmp_dir.path().join("namada_tokens_cohort_1.json");
     let mut token_file = std::fs::File::create(file_path).unwrap();
     token_file
-        .write_all("[\"7fe7c70eda056784fcf4\", \"4eb8d831fdd098390683\", \"4935c7fbd09e4f925f75\"]".as_bytes())
+        .write_all("[\"9nFeNpukSn1eVwNc2vkfP7rdLh2njm5ewmCGxSLTW3GYmKP51fKjbRUvHDmntjEaQiq7iFux9tumgWEWVHwHQCs31oitpqBpMWpMydo1DnuFyLpsD6C\", \"9nFeNpukSn1eVwNc2vkfP7sQsLG3oS7623phb2Zzc23GAdXjuby4XAbwbWbx1uNaYrZorVLio4ZSt3u95sgi4fsS8hiZ3XkEttBF6q4461dGpoWv7ek\", \"9nFeNpukSn1eVwNc2vkfP8SP4HrxTh9F86CY5pNWw8RF3jZa91q2i3yvE7ugpn9w2RzoZBZrdskgckmvJuVKq6ZWxfV8TepZYFd9SeARGHexi7tGGV2\"]".as_bytes())
         .unwrap();
     std::env::set_var("NAMADA_TOKENS_PATH", tmp_dir.path());
 
@@ -110,7 +110,7 @@ fn build_context() -> TestCtx {
     let contributor2_ip = IpAddr::V4("0.0.0.2".parse().unwrap());
     let unknown_contributor_ip = IpAddr::V4("0.0.0.3".parse().unwrap());
 
-    let token = String::from("7fe7c70eda056784fcf4");
+    let token = String::from("9nFeNpukSn1eVwNc2vkfP7rdLh2njm5ewmCGxSLTW3GYmKP51fKjbRUvHDmntjEaQiq7iFux9tumgWEWVHwHQCs31oitpqBpMWpMydo1DnuFyLpsD6C");
 
     coordinator.initialize().unwrap();
     let coordinator_keypair = KeyPair::custom_new(
@@ -276,7 +276,7 @@ fn test_update_cohorts() {
     std::fs::remove_file(TOKENS_ZIP_FILE).ok();
 
     // Create new tokens zip file
-    let new_invalid_tokens = get_serialized_tokens_zip(vec!["[\"7fe7c70eda056784fcf4\", \"4eb8d831fdd098390683\"]"]);
+    let new_invalid_tokens = get_serialized_tokens_zip(vec!["[\"9nFeNpukSn1eVwNc2vkfP7rdLh2njm5ewmCGxSLTW3GYmKP51fKjbRUvHDmntjEaQiq7iFux9tumgWEWVHwHQCs31oitpqBpMWpMydo1DnuFyLpsD6C\", \"9nFeNpukSn1eVwNc2vkfP7sQsLG3oS7623phb2Zzc23GAdXjuby4XAbwbWbx1uNaYrZorVLio4ZSt3u95sgi4fsS8hiZ3XkEttBF6q4461dGpoWv7ek\"]"]);
 
     // Wrong, request from non-coordinator participant
     let mut req = client.post("/update_cohorts");
@@ -296,8 +296,8 @@ fn test_update_cohorts() {
 
     // Valid new tokens
     let new_valid_tokens = get_serialized_tokens_zip(vec![
-        "[\"7fe7c70eda056784fcf4\", \"4eb8d831fdd098390683\", \"4935c7fbd09e4f925f75\"]",
-        "[\"4935c7fbd09e4f925f11\"]",
+        "[\"9nFeNpukSn1eVwNc2vkfP7rdLh2njm5ewmCGxSLTW3GYmKP51fKjbRUvHDmntjEaQiq7iFux9tumgWEWVHwHQCs31oitpqBpMWpMydo1DnuFyLpsD6C\", \"9nFeNpukSn1eVwNc2vkfP7sQsLG3oS7623phb2Zzc23GAdXjuby4XAbwbWbx1uNaYrZorVLio4ZSt3u95sgi4fsS8hiZ3XkEttBF6q4461dGpoWv7ek\", \"9nFeNpukSn1eVwNc2vkfP8SP4HrxTh9F86CY5pNWw8RF3jZa91q2i3yvE7ugpn9w2RzoZBZrdskgckmvJuVKq6ZWxfV8TepZYFd9SeARGHexi7tGGV2\"]",
+        "[\"9nFeNpukSn1eVwNc2vkfP8TAaw6DXNAgCNpxiQc437BxT3iF2xUMdo6wYQjqwxHwAZjVhQzdH3QMpJSbXvaDcnkVu6Ktt22AfYDypK2h72vuQK9fGNp\"]",
     ]);
 
     req = client.post("/update_cohorts");
@@ -431,7 +431,7 @@ fn test_join_queue() {
     req = set_request::<String>(
         req,
         &ctx.unknown_participant.keypair,
-        Some(&format!("7fe7c70eda056784fcf5")),
+        Some(&format!("9nFeNpukSn1eVwNc2vkfP8SP4HrxTh9F86CY5pNWw8RF3jZa91q2i3yvE7ugpn9w2RzoZBZrdskgckmvJuVKq6ZWxfV8TepZYFd9SeARGHexi7tGGV3")),
     );
     let response = req.dispatch();
     assert_eq!(response.status(), Status::Unauthorized);
@@ -449,7 +449,7 @@ fn test_join_queue() {
     req = set_request::<String>(
         req,
         &ctx.unknown_participant.keypair,
-        Some(&format!("4eb8d831fdd098390683")),
+        Some(&format!("9nFeNpukSn1eVwNc2vkfP7sQsLG3oS7623phb2Zzc23GAdXjuby4XAbwbWbx1uNaYrZorVLio4ZSt3u95sgi4fsS8hiZ3XkEttBF6q4461dGpoWv7ek")),
     );
     let response = req.dispatch();
     assert_eq!(response.status(), Status::Ok);
@@ -460,7 +460,7 @@ fn test_join_queue() {
     req = set_request::<String>(
         req,
         &ctx.contributors[1].keypair,
-        Some(&format!("4935c7fbd09e4f925f75")),
+        Some(&format!("9nFeNpukSn1eVwNc2vkfP8SP4HrxTh9F86CY5pNWw8RF3jZa91q2i3yvE7ugpn9w2RzoZBZrdskgckmvJuVKq6ZWxfV8TepZYFd9SeARGHexi7tGGV2")),
     );
     let response = req.dispatch();
     assert_eq!(response.status(), Status::Unauthorized);
@@ -472,7 +472,7 @@ fn test_join_queue() {
     req = set_request::<String>(
         req,
         &ctx.contributors[1].keypair,
-        Some(&format!("4eb8d831fdd098390683")),
+        Some(&format!("9nFeNpukSn1eVwNc2vkfP7sQsLG3oS7623phb2Zzc23GAdXjuby4XAbwbWbx1uNaYrZorVLio4ZSt3u95sgi4fsS8hiZ3XkEttBF6q4461dGpoWv7ek")),
     );
     let response = req.dispatch();
     assert_eq!(response.status(), Status::Unauthorized);
@@ -483,7 +483,7 @@ fn test_join_queue() {
     req = set_request::<String>(
         req,
         &ctx.unknown_participant.keypair,
-        Some(&format!("4935c7fbd09e4f925f75")),
+        Some(&format!("9nFeNpukSn1eVwNc2vkfP8SP4HrxTh9F86CY5pNWw8RF3jZa91q2i3yvE7ugpn9w2RzoZBZrdskgckmvJuVKq6ZWxfV8TepZYFd9SeARGHexi7tGGV2")),
     );
     let response = req.dispatch();
     assert_eq!(response.status(), Status::Unauthorized);
@@ -793,8 +793,8 @@ fn test_contribution() {
     // Update cohorts
     assert!(std::fs::metadata(TOKENS_ZIP_FILE).is_err());
     let new_valid_tokens = get_serialized_tokens_zip(vec![
-        "[\"7fe7c70eda056784fcf4\", \"4eb8d831fdd098390683\", \"4935c7fbd09e4f925f75\"]",
-        "[\"4935c7fbd09e4f925f11\"]",
+        "[\"9nFeNpukSn1eVwNc2vkfP7rdLh2njm5ewmCGxSLTW3GYmKP51fKjbRUvHDmntjEaQiq7iFux9tumgWEWVHwHQCs31oitpqBpMWpMydo1DnuFyLpsD6C\", \"9nFeNpukSn1eVwNc2vkfP7sQsLG3oS7623phb2Zzc23GAdXjuby4XAbwbWbx1uNaYrZorVLio4ZSt3u95sgi4fsS8hiZ3XkEttBF6q4461dGpoWv7ek\", \"9nFeNpukSn1eVwNc2vkfP8SP4HrxTh9F86CY5pNWw8RF3jZa91q2i3yvE7ugpn9w2RzoZBZrdskgckmvJuVKq6ZWxfV8TepZYFd9SeARGHexi7tGGV2\"]",
+        "[\"9nFeNpukSn1eVwNc2vkfP8TAaw6DXNAgCNpxiQc437BxT3iF2xUMdo6wYQjqwxHwAZjVhQzdH3QMpJSbXvaDcnkVu6Ktt22AfYDypK2h72vuQK9fGNp\"]",
     ]);
 
     req = client.post("/update_cohorts");
@@ -811,7 +811,7 @@ fn test_contribution() {
     req = set_request::<String>(
         req,
         &ctx.unknown_participant.keypair,
-        Some(&format!("4935c7fbd09e4f925f75")),
+        Some(&format!("9nFeNpukSn1eVwNc2vkfP8SP4HrxTh9F86CY5pNWw8RF3jZa91q2i3yvE7ugpn9w2RzoZBZrdskgckmvJuVKq6ZWxfV8TepZYFd9SeARGHexi7tGGV2")),
     );
     let response = req.dispatch();
     assert_eq!(response.status(), Status::Unauthorized);
@@ -824,7 +824,7 @@ fn test_contribution() {
     req = set_request::<String>(
         req,
         &ctx.unknown_participant.keypair,
-        Some(&format!("7fe7c70eda056784fcf4")),
+        Some(&format!("9nFeNpukSn1eVwNc2vkfP7rdLh2njm5ewmCGxSLTW3GYmKP51fKjbRUvHDmntjEaQiq7iFux9tumgWEWVHwHQCs31oitpqBpMWpMydo1DnuFyLpsD6C")),
     );
     let response = req.dispatch();
     assert_eq!(response.status(), Status::Unauthorized);
@@ -838,7 +838,7 @@ fn test_contribution() {
     req = set_request::<String>(
         req,
         &ctx.unknown_participant.keypair,
-        Some(&format!("4eb8d831fdd098390683")),
+        Some(&format!("9nFeNpukSn1eVwNc2vkfP7sQsLG3oS7623phb2Zzc23GAdXjuby4XAbwbWbx1uNaYrZorVLio4ZSt3u95sgi4fsS8hiZ3XkEttBF6q4461dGpoWv7ek")),
     );
     let response = req.dispatch();
     assert_eq!(response.status(), Status::Unauthorized);
@@ -849,7 +849,7 @@ fn test_contribution() {
     req = set_request::<String>(
         req,
         &ctx.unknown_participant.keypair,
-        Some(&format!("4935c7fbd09e4f925f11")),
+        Some(&format!("9nFeNpukSn1eVwNc2vkfP8TAaw6DXNAgCNpxiQc437BxT3iF2xUMdo6wYQjqwxHwAZjVhQzdH3QMpJSbXvaDcnkVu6Ktt22AfYDypK2h72vuQK9fGNp")),
     );
     let response = req.dispatch();
     assert_eq!(response.status(), Status::Ok);


### PR DESCRIPTION
Closes #65.

- Implements token blacklisting controlled by an env variable
- Fixes ip ban logic on coordinator sudden shutdown
- Implements a `RuntimeState` to handle data that should not survive a coordinator restart
- Tests token blacklisting