### PR TITLE
CLI flow refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1177,11 +1177,10 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
- "matches",
  "percent-encoding",
 ]
 
@@ -1604,11 +1603,10 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
 dependencies = [
- "matches",
  "unicode-bidi",
  "unicode-normalization",
 ]
@@ -1860,12 +1858,6 @@ checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata",
 ]
-
-[[package]]
-name = "matches"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "md-5"
@@ -2277,9 +2269,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "phase1"
@@ -2406,6 +2398,7 @@ dependencies = [
  "time 0.3.11",
  "tracing",
  "tracing-subscriber",
+ "url",
  "zip",
 ]
 
@@ -4170,13 +4163,12 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.2.2"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
 dependencies = [
  "form_urlencoded",
  "idna",
- "matches",
  "percent-encoding",
 ]
 

--- a/README.md
+++ b/README.md
@@ -25,20 +25,6 @@ In both cases it is possible to provide an optional `--custom-seed` for the RNG:
 
 For a visual overview of the contribution process refer to the [flow chart](#flowchart).
 
-## Incentivized program
-
-Namada will provide a reward for the contributors of the ceremony. When contributing, the CLI will ask if you are interested in taking part in this program: if the answer is yes then you will be asked to provide your name and email address.
-
-The client will then generate a mnemonic that you **NEED** to store safely somewhere. This file should then be passed to the following command
-
-```
-namada-ts export-keypair <PATH-TO-MNEMONIC-FILE>
-```
-
-which will generate a `wallet.toml` file containing your Namada account. You can then import the content of this file into your wallet.
-
-This address will be added to the Namada genesis file with the predefined amount of tokens. We'll compute the address from the public key that you used during the contribution, you don't need to communicate it to us.
-
 ## Building and contributing from source
 
 First, [install Rust](https://www.rust-lang.org/tools/install) by entering the following command:
@@ -144,7 +130,7 @@ This section describes how it feels to contribute to the ceremony.
 
 ### Client Contribution Flow 
 
-1. The client will ask you if you want to take part in the incentivized program. If you answer 'yes', it will generate a secret mnemonic that derives your key pair.  Back up your mnemonic and keep it in a safe place! This is the only way to prove your contribution and claim your rewards later.
+1. The client will generate a secret mnemonic that derives your key pair.  Back up your mnemonic and keep it in a safe place! This is the only way to prove your contribution.
 
 2. Then, you will need to provide the unique token for your cohort you received by email. If the token is valid, you will join the queue of the ceremony. You will need to wait a bit until it is your turn. Each round lasts between 4 min and 20 min. During the whole ceremony, please neither close your terminal, nor your internet connection. If you stay offline for more than 2 min, the coordinator will kick you out from the queue.
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ mv target/release/namada-ts /usr/local/bin
 
 Start your contribution
 ```
-namada-ts contribute default https://contribute.namada.net
+namada-ts contribute default https://contribute.namada.net $TOKEN
 ```
 
 ## Contributing from prebuilt binaries (manual setup)
@@ -79,7 +79,7 @@ After download, you might need to give execution permissions with `chmod +x nama
 
 Finally start the client with:
 ```
-./namada-ts-{distrib}-{version} contribute default https://contribute.namada.net
+./namada-ts-{distrib}-{version} contribute default https://contribute.namada.net $TOKEN
 ```
 
 ## Contributing from prebuilt binaries (automated setup)
@@ -90,7 +90,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/anoma/nam
 
 and you are ready to contribute:
 ```
-namada-ts contribute default https://contribute.namada.net
+namada-ts contribute default https://contribute.namada.net $TOKEN
 ```
 
 ### Troubleshooting
@@ -105,7 +105,7 @@ You can generate the parameters on a machine that is offline or never connected 
 On the online machine give the following command:
 
 ```
-cargo run --release --bin namada-ts --features cli contribute another-machine https://contribute.namada.net
+cargo run --release --bin namada-ts --features cli contribute another-machine https://contribute.namada.net $TOKEN
 ```
 
 This will start the communication process to join the ceremony and download/upload the necessary files. On the offline machine use the following command:
@@ -121,7 +121,7 @@ You can provide your own random seed (32 bytes) to initialize the ChaCha RNG. Th
 
 To use this feature, add the `--custom-seed` flag to your command:
 ```
-cargo run --release --bin namada-ts --features cli contribute default --custom-seed https://contribute.namada.net
+cargo run --release --bin namada-ts --features cli contribute default --custom-seed https://contribute.namada.net $TOKEN
 ```
 
 This flag is available also when contributing offline:

--- a/phase1-cli/src/bin/namada-ts.rs
+++ b/phase1-cli/src/bin/namada-ts.rs
@@ -459,10 +459,11 @@ async fn contribution_loop(
         };
     }
 
-    requests::post_join_queue(&client, &coordinator, &keypair, &token)
+    let cohort = requests::post_join_queue(&client, &coordinator, &keypair, &token)
         .await
         .expect(&format!("{}", "Couldn't join the queue".red().bold()));
     contrib_info.timestamps.joined_queue = Utc::now();
+    contrib_info.joined_cohort = cohort;
 
     // Spawn heartbeat task to prevent the Coordinator from
     // dropping the contributor out of the ceremony in the middle of a contribution.

--- a/phase1-cli/src/bin/namada-ts.rs
+++ b/phase1-cli/src/bin/namada-ts.rs
@@ -546,9 +546,21 @@ async fn contribution_loop(
                                 contrib_info.contribution_hash,
                 format!("You also find all the metadata of your contribution (ceremony round, contribution hash, public key, timestamps etc.) in the \"namada_contributior_info_round_{}.json\"",round_height).as_str().bright_cyan()
                                 );
-                println!("{}", ASCII_CONTRIBUTION_DONE.bright_yellow());
+                println!("{}\n", ASCII_CONTRIBUTION_DONE.bright_yellow());
 
-                break;
+                // Attestation
+                if "n" == io::get_user_input("Would you like to provide an attestation of your contribution? [y/n]".bright_yellow(), Some(&Regex::new(r"^(?i)[yn]$").unwrap())).unwrap() {
+                    break;
+                } else {
+                    loop {
+                        let attestation_url = io::get_user_input("Please enter a valid url for your attestation:".bright_yellow(), None).unwrap();
+                        if Url::parse(attestation_url.as_str()).is_ok() {
+                            // Send attestation to coordinator
+                            requests::post_attestation(&client, &coordinator, &keypair, &attestation_url).await.expect(&format!("{}", "Failed attestation upload".red().bold()));
+                            return;
+                        }
+                    }
+                }
             }
             ContributorStatus::Banned => {
                 println!(

--- a/phase1-cli/src/bin/namada-ts.rs
+++ b/phase1-cli/src/bin/namada-ts.rs
@@ -3,7 +3,7 @@ use phase1_coordinator::{
     commands::{Computation, RandomSource, SEED_LENGTH},
     io::{self, KeyPairUser, verify_signature},
     objects::{ContributionFileSignature, ContributionInfo, ContributionState, TrimmedContributionInfo},
-    rest_utils::{ContributorStatus, PostChunkRequest, TOKENS_ZIP_FILE, TOKEN_REGEX, UPDATE_TIME},
+    rest_utils::{ContributorStatus, PostChunkRequest, TOKENS_ZIP_FILE, UPDATE_TIME},
     storage::Object,
 };
 
@@ -427,18 +427,10 @@ async fn contribution_loop(
     client: Arc<Client>,
     coordinator: Arc<Url>,
     keypair: Arc<KeyPair>,
+    token: String,
     mut contrib_info: ContributionInfo,
 ) {
     println!("{} Joining queue", "[3/11]".bold().dimmed());
-    println!(
-        "{}",
-        "You can only join the ceremony with the unique token you received by email for your cohort.".bright_cyan()
-    );
-    let token = io::get_user_input(
-        "Enter your token:".bright_yellow(),
-        Some(&Regex::new(TOKEN_REGEX).unwrap()),
-    )
-    .unwrap();
 
     let (prefix, internal_token) = token.split_once("_").unwrap();
 
@@ -464,7 +456,7 @@ async fn contribution_loop(
                 _ => (),
             }
         } else {
-            println!("The token provided is not valid.");
+            println!("The token provided is not base58 encoded.");
             process::exit(0);
         };
     }
@@ -646,7 +638,7 @@ enum Branch {
 
 /// Performs the entire contribution cycle
 #[inline(always)]
-async fn contribution_prelude(url: CoordinatorUrl, branch: Branch) {
+async fn contribution_prelude(url: CoordinatorUrl, token: String, branch: Branch) {
     // Check that the passed-in coordinator url is correct
     let client = Client::new();
     requests::ping_coordinator(&client, &url.coordinator)
@@ -686,7 +678,7 @@ async fn contribution_prelude(url: CoordinatorUrl, branch: Branch) {
     match branch {
         Branch::AnotherMachine => contrib_info.is_another_machine = true,
         Branch::Default(custom_seed) if custom_seed => contrib_info.is_own_seed_of_randomness = true,
-        _ => (),
+        _ => unreachable!(),
     }
 
     if contrib_info.is_incentivized {
@@ -717,6 +709,7 @@ async fn contribution_prelude(url: CoordinatorUrl, branch: Branch) {
         Arc::new(client),
         Arc::new(url.coordinator),
         Arc::new(keypair),
+        token,
         contrib_info,
     )
     .await;
@@ -730,9 +723,9 @@ async fn main() {
     match opt {
         CeremonyOpt::Contribute(branch) => {
             match branch {
-                phase1_cli::Branches::AnotherMachine { url } => contribution_prelude(url, Branch::AnotherMachine).await,
-                phase1_cli::Branches::Default { url, custom_seed } => {
-                    contribution_prelude(url, Branch::Default(custom_seed)).await
+                phase1_cli::Branches::AnotherMachine { request } => contribution_prelude(request.url, request.token, Branch::AnotherMachine).await,
+                phase1_cli::Branches::Default { request, custom_seed } => {
+                    contribution_prelude(request.url, request.token, Branch::Default(custom_seed)).await
                 }
                 phase1_cli::Branches::Offline { custom_seed } => {
                     if custom_seed {
@@ -835,7 +828,7 @@ async fn main() {
             get_contributions(&url.coordinator).await;
         }
         CeremonyOpt::GetState(state) => {
-            let secret = state.secret.as_str();
+            let secret = state.token.as_str();
             get_coordinator_state(&state.url.coordinator, secret).await;
         }
         CeremonyOpt::UpdateCohorts(url) => {

--- a/phase1-cli/src/lib.rs
+++ b/phase1-cli/src/lib.rs
@@ -121,7 +121,7 @@ pub struct VerifySignatureContribution {
     #[structopt(about = "The contribution message hash")]
     pub message: String,
     #[structopt(about = "The contribution signature")]
-    pub signature: String
+    pub signature: String,
 }
 
 #[derive(Debug, StructOpt)]

--- a/phase1-cli/src/lib.rs
+++ b/phase1-cli/src/lib.rs
@@ -135,6 +135,7 @@ pub enum CeremonyOpt {
     ExportKeypair(MnemonicPath),
     #[structopt(about = "Generate the list of addresses of the contributors")]
     GenerateAddresses(Contributors),
+    #[cfg(debug_assertions)]
     #[structopt(about = "Get a list of all the contributions received")]
     GetContributions(CoordinatorUrl),
     #[structopt(about = "Get the state of the coordinator")]

--- a/phase1-cli/src/lib.rs
+++ b/phase1-cli/src/lib.rs
@@ -28,12 +28,13 @@ pub struct CoordinatorUrl {
     pub coordinator: Url,
 }
 
+/// Accepts both the ceremony token and the secret token for reserved endpoints
 #[derive(Debug, StructOpt)]
-pub struct CoordinatorState {
+pub struct RequestWithToken {
     #[structopt(flatten)]
     pub url: CoordinatorUrl,
     #[structopt(help = "The secret token required for the request")]
-    pub secret: String,
+    pub token: String,
 }
 
 #[derive(Debug, StructOpt)]
@@ -62,12 +63,12 @@ pub enum Branches {
     )]
     AnotherMachine {
         #[structopt(flatten)]
-        url: CoordinatorUrl,
+        request: RequestWithToken,
     },
     #[structopt(about = "The default contribution path, executes both communication and computation on this machine")]
     Default {
         #[structopt(flatten)]
-        url: CoordinatorUrl,
+        request: RequestWithToken,
         #[structopt(
             long,
             help = "Give a custom random seed (32 bytes / 64 characters in hexadecimal) for the ChaCha RNG"
@@ -137,7 +138,7 @@ pub enum CeremonyOpt {
     #[structopt(about = "Get a list of all the contributions received")]
     GetContributions(CoordinatorUrl),
     #[structopt(about = "Get the state of the coordinator")]
-    GetState(CoordinatorState),
+    GetState(RequestWithToken),
     #[cfg(debug_assertions)]
     #[structopt(about = "Verify the pending contributions")]
     VerifyContributions(CoordinatorUrl),

--- a/phase1-cli/src/requests.rs
+++ b/phase1-cli/src/requests.rs
@@ -421,6 +421,26 @@ pub async fn post_contribution_info(
     Ok(())
 }
 
+/// Send an attestation of the contribution to the Coordinator.
+pub async fn post_attestation(
+    client: &Client,
+    coordinator_address: &Url,
+    keypair: &KeyPair,
+    request_body: &String,
+) -> Result<()> {
+    submit_request::<String>(
+        client,
+        coordinator_address,
+        "/contributor/attestation",
+        Some(keypair),
+        None,
+        Request::Post(Some(request_body)),
+    )
+    .await?;
+
+    Ok(())
+}
+
 /// Query health endpoint of the Coordinator to check the connection
 pub async fn ping_coordinator(client: &Client, coordinator_address: &Url) -> Result<()> {
     submit_request::<()>(client, coordinator_address, "/healthcheck", None, None, Request::Get).await?;

--- a/phase1-cli/src/requests.rs
+++ b/phase1-cli/src/requests.rs
@@ -191,8 +191,8 @@ pub async fn post_join_queue(
     coordinator_address: &Url,
     keypair: &KeyPair,
     token: &String,
-) -> Result<()> {
-    submit_request::<String>(
+) -> Result<u64> {
+    let response = submit_request::<String>(
         client,
         coordinator_address,
         "contributor/join_queue",
@@ -202,7 +202,7 @@ pub async fn post_join_queue(
     )
     .await?;
 
-    Ok(())
+    Ok(response.json::<u64>().await?)
 }
 
 /// Send a request to the [Coordinator](`phase1-coordinator::Coordinator`) to lock the next [Chunk](`phase1-coordinator::objects::Chunk`).

--- a/phase1-cli/src/requests.rs
+++ b/phase1-cli/src/requests.rs
@@ -429,6 +429,7 @@ pub async fn ping_coordinator(client: &Client, coordinator_address: &Url) -> Res
 }
 
 /// Retrieve the list of contributions, json encoded
+#[cfg(debug_assertions)]
 pub async fn get_contributions_info(coordinator_address: &Url) -> Result<Vec<u8>> {
     let client = Client::builder().brotli(true).build()?;
 

--- a/phase1-coordinator/Cargo.toml
+++ b/phase1-coordinator/Cargo.toml
@@ -46,6 +46,7 @@ thiserror = {version = "1.0"}
 time = {version = "0.3", features = ["serde-human-readable", "macros"]}
 tracing = {version = "0.1"}
 tracing-subscriber = {version = "0.3"}
+url = "2.3.1"
 
 # Imports from the crates included in Cargo.toml of `heliaxdev/masp-mpc` on branch `joe/update`
 # Used in the crypto commands of the coordinator

--- a/phase1-coordinator/src/coordinator.rs
+++ b/phase1-coordinator/src/coordinator.rs
@@ -1709,6 +1709,42 @@ impl Coordinator {
         )
     }
 
+    /// Updates the contribution attestation and summary to storage at the appropriate locator.
+    pub(crate) fn update_contribution_info_attestation(&mut self, round: u64, attestation: String) -> Result<(), CoordinatorError> {
+        // Retrieve current file to update
+        let updated_info = match self.storage.get(&Locator::ContributionInfoFile{
+            round_height: round,
+        })? {
+            Object::ContributionInfoFile(info) => ContributionInfo {
+                attestation: Some(attestation),
+                ..info
+            },
+            _ => return Err(CoordinatorError::StorageFailed)
+        };
+
+        // Persist update to storage
+        self.storage.update(&Locator::ContributionInfoFile{
+            round_height: round,
+        }, Object::ContributionInfoFile(updated_info.clone()))?;
+
+        // Update the summary
+        let mut summary = match self.storage.get(&Locator::ContributionsInfoSummary)? {
+            Object::ContributionsInfoSummary(summary) => summary,
+            _ => return Err(CoordinatorError::StorageFailed),
+        };
+
+        match summary.get_mut((round - 1) as usize) {
+            Some(t) => *t = updated_info.into(),
+            None => return Err(CoordinatorError::StorageFailed),
+        };
+
+        // Persist update to storage
+        self.storage.update(
+            &Locator::ContributionsInfoSummary,
+            Object::ContributionsInfoSummary(summary),
+        )
+    }
+
     /// Appends current round summary to storage at the appropriate locator.
     pub(crate) fn update_contribution_summary(
         &mut self,

--- a/phase1-coordinator/src/coordinator.rs
+++ b/phase1-coordinator/src/coordinator.rs
@@ -1710,22 +1710,28 @@ impl Coordinator {
     }
 
     /// Updates the contribution attestation and summary to storage at the appropriate locator.
-    pub(crate) fn update_contribution_info_attestation(&mut self, round: u64, attestation: String) -> Result<(), CoordinatorError> {
+    pub(crate) fn update_contribution_info_attestation(
+        &mut self,
+        round: u64,
+        attestation: String,
+    ) -> Result<(), CoordinatorError> {
         // Retrieve current file to update
-        let updated_info = match self.storage.get(&Locator::ContributionInfoFile{
-            round_height: round,
-        })? {
+        let updated_info = match self
+            .storage
+            .get(&Locator::ContributionInfoFile { round_height: round })?
+        {
             Object::ContributionInfoFile(info) => ContributionInfo {
                 attestation: Some(attestation),
                 ..info
             },
-            _ => return Err(CoordinatorError::StorageFailed)
+            _ => return Err(CoordinatorError::StorageFailed),
         };
 
         // Persist update to storage
-        self.storage.update(&Locator::ContributionInfoFile{
-            round_height: round,
-        }, Object::ContributionInfoFile(updated_info.clone()))?;
+        self.storage.update(
+            &Locator::ContributionInfoFile { round_height: round },
+            Object::ContributionInfoFile(updated_info.clone()),
+        )?;
 
         // Update the summary
         let mut summary = match self.storage.get(&Locator::ContributionsInfoSummary)? {

--- a/phase1-coordinator/src/io.rs
+++ b/phase1-coordinator/src/io.rs
@@ -217,7 +217,7 @@ pub fn verify_signature(pubkey: String, signature: String, message: String) -> b
         (Ok(pk), Ok(signature)) => {
             match pk.verify(&message, &signature) {
                 Ok(_) => true,
-                Err(e) => {
+                Err(_) => {
                     false
                 },
             }

--- a/phase1-coordinator/src/io.rs
+++ b/phase1-coordinator/src/io.rs
@@ -35,7 +35,6 @@ pub enum IOError {
 pub enum KeyPairUser {
     Contributor,
     Coordinator,
-    IncentivizedContributor,
 }
 
 type Result<T> = std::result::Result<T, IOError>;
@@ -160,9 +159,8 @@ pub fn keypair_from_mnemonic() -> Result<KeyPair> {
 
 /// Generates a new [`KeyPair`] from a randomly generated mnemonic.
 /// Cases:
-/// - Contributor -> generate keypair in the background without notifying the user
+/// - Contributor -> print and check the mnemonic with the user
 /// - Coordinator -> save the mnemonic to a file
-/// - IncentivizedContributor -> print and check the mnemonic with the user
 pub fn generate_keypair(user: KeyPairUser) -> Result<KeyPair> {
     // Generate random mnemonic
     let mut rng = rand_06::thread_rng();
@@ -171,9 +169,8 @@ pub fn generate_keypair(user: KeyPairUser) -> Result<KeyPair> {
         .into();
 
     match user {
-        KeyPairUser::Contributor => (),
         KeyPairUser::Coordinator => std::fs::write(COORDINATOR_MNEMONIC_FILE, mnemonic.to_string())?,
-        KeyPairUser::IncentivizedContributor => {
+        KeyPairUser::Contributor => {
             // Print mnemonic to the user in a different terminal
             execute!(std::io::stdout(), EnterAlternateScreen)?;
             println!("{}", "Safely store your 24 words mnemonic:\n".bright_cyan());

--- a/phase1-coordinator/src/io.rs
+++ b/phase1-coordinator/src/io.rs
@@ -211,17 +211,11 @@ pub fn verify_signature(pubkey: String, signature: String, message: String) -> b
     let signature = ed25519_compact::Signature::from_slice(&hex::decode(signature).unwrap());
 
     match (pk, signature) {
-        (Ok(pk), Ok(signature)) => {
-            match pk.verify(&message, &signature) {
-                Ok(_) => true,
-                Err(_) => {
-                    false
-                },
-            }
-        }
-        _ => {
-            false   
-        }
+        (Ok(pk), Ok(signature)) => match pk.verify(&message, &signature) {
+            Ok(_) => true,
+            Err(_) => false,
+        },
+        _ => false,
     }
 }
 

--- a/phase1-coordinator/src/objects/contribution_info.rs
+++ b/phase1-coordinator/src/objects/contribution_info.rs
@@ -94,6 +94,8 @@ pub struct ContributionInfo {
     pub contribution_file_hash: String,
     // Signature of the contribution
     pub contribution_file_signature: String,
+    /// Url providing an attestation of the contribution
+    pub attestation: Option<String>
     // Some timestamps to get performance metrics of the ceremony
     pub timestamps: ContributionTimeStamps,
     // Signature of this struct, computed on the json string encoding of all the other fields of this struct
@@ -162,6 +164,7 @@ pub struct TrimmedContributionInfo {
     ceremony_round: u64,
     contribution_hash: String,
     contribution_hash_signature: String,
+    attestation: Option<String>,
     timestamps: TrimmedContributionTimeStamps,
 }
 
@@ -176,6 +179,7 @@ impl From<ContributionInfo> for TrimmedContributionInfo {
             ceremony_round: parent.ceremony_round,
             contribution_hash: parent.contribution_file_hash,
             contribution_hash_signature: parent.contribution_file_signature,
+            attestation: parent.attestation,
             timestamps: parent.timestamps.into(),
         }
     }

--- a/phase1-coordinator/src/objects/contribution_info.rs
+++ b/phase1-coordinator/src/objects/contribution_info.rs
@@ -82,6 +82,8 @@ pub struct ContributionInfo {
     pub is_another_machine: bool,
     // User can choose the default method to generate randomness or his own.
     pub is_own_seed_of_randomness: bool,
+    // Cohort in which the participant joined the queue
+    pub joined_cohort: u64,
     // Round in which the contribution took place
     pub ceremony_round: u64,
     // Hash of the contribution run by masp-mpc, contained in the transcript
@@ -156,6 +158,7 @@ pub struct TrimmedContributionInfo {
     public_key: String,
     is_another_machine: bool,
     is_own_seed_of_randomness: bool,
+    joined_cohort: u64,
     ceremony_round: u64,
     contribution_hash: String,
     contribution_hash_signature: String,
@@ -169,6 +172,7 @@ impl From<ContributionInfo> for TrimmedContributionInfo {
             public_key: parent.public_key,
             is_another_machine: parent.is_another_machine,
             is_own_seed_of_randomness: parent.is_own_seed_of_randomness,
+            joined_cohort: parent.joined_cohort,
             ceremony_round: parent.ceremony_round,
             contribution_hash: parent.contribution_file_hash,
             contribution_hash_signature: parent.contribution_file_signature,

--- a/phase1-coordinator/src/objects/contribution_info.rs
+++ b/phase1-coordinator/src/objects/contribution_info.rs
@@ -78,8 +78,6 @@ pub struct ContributionInfo {
     pub email: Option<String>,
     // ed25519 public key, hex encoded
     pub public_key: String,
-    // User participates in incentivized program or not
-    pub is_incentivized: bool,
     // User can choose to contribute on another machine
     pub is_another_machine: bool,
     // User can choose the default method to generate randomness or his own.
@@ -154,6 +152,7 @@ impl ContributionInfo {
 /// A summarized version of [`ContributionInfo`]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct TrimmedContributionInfo {
+    full_name: Option<String>,
     public_key: String,
     is_another_machine: bool,
     is_own_seed_of_randomness: bool,
@@ -166,12 +165,13 @@ pub struct TrimmedContributionInfo {
 impl From<ContributionInfo> for TrimmedContributionInfo {
     fn from(parent: ContributionInfo) -> Self {
         Self {
+            full_name: parent.full_name,
             public_key: parent.public_key,
             is_another_machine: parent.is_another_machine,
             is_own_seed_of_randomness: parent.is_own_seed_of_randomness,
             ceremony_round: parent.ceremony_round,
-            contribution_hash: parent.contribution_hash,
-            contribution_hash_signature: parent.contribution_hash_signature,
+            contribution_hash: parent.contribution_file_hash,
+            contribution_hash_signature: parent.contribution_file_signature,
             timestamps: parent.timestamps.into(),
         }
     }
@@ -216,7 +216,6 @@ mod tests {
         // Test custom
         test_info.full_name = Some(String::from("Test Name"));
         test_info.email = Some(String::from("test_name@test.dev"));
-        test_info.is_incentivized = true;
         test_info.ceremony_round = 12;
         test_info.contribution_hash = String::from("Not a valid hash");
         test_info.contribution_hash_signature = String::from("Not a valid signature");

--- a/phase1-coordinator/src/objects/contribution_info.rs
+++ b/phase1-coordinator/src/objects/contribution_info.rs
@@ -95,7 +95,7 @@ pub struct ContributionInfo {
     // Signature of the contribution
     pub contribution_file_signature: String,
     /// Url providing an attestation of the contribution
-    pub attestation: Option<String>
+    pub attestation: Option<String>,
     // Some timestamps to get performance metrics of the ceremony
     pub timestamps: ContributionTimeStamps,
     // Signature of this struct, computed on the json string encoding of all the other fields of this struct

--- a/phase1-coordinator/src/rest.rs
+++ b/phase1-coordinator/src/rest.rs
@@ -177,7 +177,7 @@ pub async fn stop_coordinator(_auth: ServerAuth, shutdown: Shutdown) {
 #[cfg(debug_assertions)]
 #[get("/verify")]
 pub async fn verify_chunks(coordinator: &State<Coordinator>, _auth: ServerAuth) -> Result<()> {
-    rest_utils::perform_verify_chunks((*coordinator).clone()).await
+    rest_utils::perform_verify_chunks((*coordinator).clone(), &S3Ctx::new().await?).await
 }
 
 /// Load new tokens to update the future cohorts. The `tokens` parameter is the serialized zip folder
@@ -347,6 +347,7 @@ pub async fn post_contribution_info(
 }
 
 /// Retrieve the contributions' info. This endpoint is accessible by anyone and does not require a signed request.
+#[cfg(debug_assertions)]
 #[get("/contribution_info")]
 pub async fn get_contributions_info(coordinator: &State<Coordinator>) -> Result<Vec<u8>> {
     let read_lock = (*coordinator).clone().read_owned().await;

--- a/phase1-coordinator/src/rest_utils.rs
+++ b/phase1-coordinator/src/rest_utils.rs
@@ -686,12 +686,18 @@ pub async fn perform_verify_chunks(coordinator: Coordinator, s3_ctx: &S3Ctx) -> 
             }
         }
 
-        write_lock.storage().get_contributions_summary().map_err(|e| ResponseError::CoordinatorError(e))
+        write_lock
+            .storage()
+            .get_contributions_summary()
+            .map_err(|e| ResponseError::CoordinatorError(e))
     })
     .await??;
 
     // Upload json file to S3
-    s3_ctx.upload_contributions_info(contributions_info).await.map_err(|e| ResponseError::CoordinatorError(CoordinatorError::Error(anyhow!(e.to_string()))))
+    s3_ctx
+        .upload_contributions_info(contributions_info)
+        .await
+        .map_err(|e| ResponseError::CoordinatorError(CoordinatorError::Error(anyhow!(e.to_string()))))
 }
 
 /// Performs the update of the [Coordinator](`crate::Coordinator`)

--- a/phase1-coordinator/src/rest_utils.rs
+++ b/phase1-coordinator/src/rest_utils.rs
@@ -616,7 +616,7 @@ impl PostChunkRequest {
 
 /// Checks the validity of the token for the ceremony.
 /// Returns the current cohort index
-pub(crate) async fn token_check(coordinator: Coordinator, token: &str) -> Result<()> {
+pub(crate) async fn token_check(coordinator: Coordinator, token: &str) -> Result<u64> {
     // Check that token is not in use nor blacklisted (only if env is set)
     let read_lock = coordinator.read().await;
     if *TOKEN_BLACKLIST {
@@ -640,7 +640,7 @@ pub(crate) async fn token_check(coordinator: Coordinator, token: &str) -> Result
         return Err(ResponseError::InvalidToken(cohort + 1));
     }
 
-    Ok(())
+    Ok((cohort + 1) as u64)
 }
 
 /// Performs the verification of the pending contributions

--- a/phase1-coordinator/src/s3.rs
+++ b/phase1-coordinator/src/s3.rs
@@ -76,6 +76,21 @@ impl S3Ctx {
         })
     }
 
+    /// Upload contributors.json file to S3 for the frontend
+    pub(crate) async fn upload_contributions_info(&self, contributions_info: Vec<u8>) -> Result<()> {
+        let put_object_request = PutObjectRequest {
+            bucket: self.bucket.clone(),
+            key: "contributors.json".to_string(),
+            body: Some(StreamingBody::from(contributions_info)),
+            ..Default::default()
+        };
+
+        self.client
+            .put_object(put_object_request)
+            .await
+            .map_or_else(|e| Err(S3Error::UploadError(e.to_string())), |_| Ok(()))
+    }
+
     /// Get the url of a challenge on S3.
     pub(crate) async fn get_challenge_url(&self, key: String) -> Option<String> {
         let head = HeadObjectRequest {

--- a/phase1-coordinator/src/s3.rs
+++ b/phase1-coordinator/src/s3.rs
@@ -4,12 +4,13 @@ use rusoto_core::{region::Region, request::TlsError};
 use rusoto_credential::{AwsCredentials, ChainProvider, CredentialsError, ProvideAwsCredentials};
 use rusoto_s3::{
     util::{PreSignedRequest, PreSignedRequestOption},
+    DeleteObjectRequest,
     GetObjectRequest,
     HeadObjectRequest,
     PutObjectRequest,
     S3Client,
     StreamingBody,
-    S3, DeleteObjectRequest,
+    S3,
 };
 use std::str::FromStr;
 use thiserror::Error;
@@ -89,7 +90,7 @@ impl S3Ctx {
             .delete_object(delete_object_request)
             .await
             .map_or_else(|e| Err(S3Error::UploadError(e.to_string())), |_| Ok(()))?;
-        
+
         // Upload the updated file
         let put_object_request = PutObjectRequest {
             bucket: self.bucket.clone(),


### PR DESCRIPTION
Closes #68 

- Adds attestation and cohort to `ContributionInfo`
- Adds the relative endpoint and request
- Token as CLI argument instead of interactive I/O
- Uploads contributions info to S3
- Removes mentions of incentives
- Fixes `TrimmedContributionInfo`